### PR TITLE
:bug: empty computedResults in database

### DIFF
--- a/src/routes/groups/fetchGroup.ts
+++ b/src/routes/groups/fetchGroup.ts
@@ -48,7 +48,10 @@ router.route('/').post(async (req, res) => {
     for (const participant of group.participants) {
       const { simulation } = participant
 
-      if (!simulation || !!simulation.computedResults) {
+      if (
+        !simulation ||
+        (!!simulation.computedResults && !!simulation.computedResults.carbone)
+      ) {
         continue
       }
 

--- a/src/routes/simulations/fetchSimulation.ts
+++ b/src/routes/simulations/fetchSimulation.ts
@@ -31,7 +31,10 @@ router.route('/').post(async (req, res) => {
       return res.status(404).send('No matching simulation found.')
     }
 
-    if (!simulationFound.computedResults) {
+    if (
+      !simulationFound.computedResults ||
+      !simulationFound.computedResults.carbone
+    ) {
       const situationMigrated = migrateSituation(
         simulationFound.situation,
         migrationInstructionsJSON


### PR DESCRIPTION
Certains `computedResults` sont vides `{}` en base... On les recalcule à la volée désormais