### PR TITLE
:sparkles: agir export situation use-case NGC-1294

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,5 @@
+AGIR_API_KEY=agir_api_key # can be found on scalingo
+AGIR_URL=agir_url # can be found on scalingo
 BREVO_API_KEY=brevo_api_key # can be found on scalingo
 CONNECT_CLIENT_ID=connect_client_id # can be found on scalingo
 CONNECT_CLIENT_SECRET=connect_client_secret # can be found on scalingo

--- a/jest.env.ts
+++ b/jest.env.ts
@@ -1,6 +1,8 @@
 const MONGO_PORT = 27017 + parseInt(process.env.JEST_WORKER_ID || '0', 10)
 
 process.env.MONGO_URL = `mongodb://127.0.0.1:${MONGO_PORT}/ngc`
+process.env.AGIR_URL = 'https://api.agir.com'
+process.env.AGIR_API_KEY = 'mySuperTestAgirSecret'
 process.env.BREVO_URL = 'https://api.brevo.com'
 process.env.BREVO_API_KEY = 'mySuperTestBrevoSecret'
 process.env.CONNECT_URL = 'http://connect.fr'

--- a/src/adapters/agir/client.ts
+++ b/src/adapters/agir/client.ts
@@ -1,0 +1,31 @@
+import axios from 'axios'
+import axiosRetry from 'axios-retry'
+import { config } from '../../config'
+import { isNetworkOrTimeoutOrRetryableError } from '../../core/typeguards/isRetryableAxiosError'
+import type { SituationSchema } from '../../features/simulations/simulations.validator'
+
+const agir = axios.create({
+  baseURL: config.thirdParty.agir.url,
+  headers: {
+    apikey: config.thirdParty.agir.apiKey,
+  },
+  timeout: 1000,
+})
+
+axiosRetry(agir, {
+  retryCondition: isNetworkOrTimeoutOrRetryableError,
+  retryDelay: () => 200,
+  shouldResetTimeout: true,
+})
+
+export const exportSituation = async (situation: SituationSchema) => {
+  const {
+    data: { redirect_url },
+  } = await agir.post<{ redirect_url: string }>('/bilan/importFromNGC', {
+    situation,
+  })
+
+  return {
+    redirectUrl: redirect_url,
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,9 @@ import updateGroupRoute from './routes/groups/updateGroup'
 import fetchGroupsRoute from './routes/groups/fetchGroups'
 import removeParticipantRoute from './routes/groups/removeParticipant'
 
+// Integrations routes
+import integrationsController from './features/integrations/integrations.controller'
+
 // Organisation routes
 import createOrganisationRoute from './routes/organisations/create'
 import fetchOrganisationRoute from './routes/organisations/fetchOrganisation'
@@ -116,6 +119,9 @@ app.use('/groups', groupsController)
 // Group participants routes
 app.use('/group/fetch-groups', fetchGroupsRoute)
 app.use('/group/remove-participant', removeParticipantRoute)
+
+//Integrations routes
+app.use('/integrations', integrationsController)
 
 // Organisation routes
 app.use('/organisations/create', createOrganisationRoute)

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,10 @@ export const config = {
     },
   },
   thirdParty: {
+    agir: {
+      url: ensureEnvVar(process.env.AGIR_URL, ''),
+      apiKey: ensureEnvVar(process.env.AGIR_API_KEY, ''),
+    },
     brevo: {
       url: ensureEnvVar(process.env.BREVO_URL, 'https://api.brevo.com'),
       apiKey: ensureEnvVar(process.env.BREVO_API_KEY, ''),

--- a/src/features/integrations/__tests__/export-situation.spec.ts
+++ b/src/features/integrations/__tests__/export-situation.spec.ts
@@ -1,0 +1,113 @@
+import { StatusCodes } from 'http-status-codes'
+import nock from 'nock'
+import supertest from 'supertest'
+import app from '../../../app'
+import logger from '../../../logger'
+import { getRandomPersonaSituation } from '../../simulations/__tests__/fixtures/simulations.fixtures'
+import type { SituationSchema } from '../../simulations/simulations.validator'
+
+describe('Given a NGC user', () => {
+  const agent = supertest(app)
+  const url = '/integrations/v1/:externalService/export-situation'
+
+  describe('When exporting his simulation situation', () => {
+    let situation: SituationSchema
+
+    beforeEach(() => (situation = getRandomPersonaSituation()))
+
+    describe('And no data provided', () => {
+      test(`Then it should return a ${StatusCodes.BAD_REQUEST} error`, async () => {
+        await agent.post(url).expect(StatusCodes.BAD_REQUEST)
+      })
+    })
+
+    describe('And invalid external Service', () => {
+      test(`Then it should return a ${StatusCodes.BAD_REQUEST} error`, async () => {
+        await agent.post(url).send(situation).expect(StatusCodes.BAD_REQUEST)
+      })
+    })
+
+    describe('And agir external service', () => {
+      const serviceName = 'agir'
+
+      test(`Then it should return a ${StatusCodes.OK} with a redirectionUrl`, async () => {
+        nock(process.env.AGIR_URL!).post('/bilan/importFromNGC').reply(200, {
+          redirect_url: 'http://app.agir.com',
+        })
+
+        const response = await agent
+          .post(url.replace(':externalService', serviceName))
+          .send(situation)
+          .expect(StatusCodes.OK)
+
+        expect(response.body).toEqual({
+          redirectUrl: 'http://app.agir.com',
+        })
+      })
+
+      it(`Then it should send situation on agir service`, async () => {
+        const scope = nock(process.env.AGIR_URL!, {
+          reqheaders: {
+            apikey: process.env.AGIR_API_KEY!,
+          },
+        })
+          .post(`/bilan/importFromNGC`, JSON.stringify({ situation }))
+          .reply(200, {
+            redirect_url: 'http://app.agir.com',
+          })
+
+        await agent
+          .post(url.replace(':externalService', serviceName))
+          .send(situation)
+          .expect(StatusCodes.OK)
+
+        expect(scope.isDone()).toBeTruthy()
+      })
+
+      describe(`And service is down`, () => {
+        it(`Should retry several times and then raise the exception`, async () => {
+          nock(process.env.AGIR_URL!)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+
+          await agent
+            .post(url.replace(':externalService', serviceName))
+            .send(situation)
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        })
+
+        it(`Should log the exception`, async () => {
+          nock(process.env.AGIR_URL!)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+            .post('/bilan/importFromNGC')
+            .reply(500)
+
+          await agent
+            .post(url.replace(':externalService', serviceName))
+            .send(situation)
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'Situation export failed',
+            expect.objectContaining({
+              message: 'Request failed with status code 500',
+              name: 'AxiosError',
+              code: 'ERR_BAD_RESPONSE',
+            })
+          )
+        })
+      })
+    })
+  })
+})

--- a/src/features/integrations/integrations.controller.ts
+++ b/src/features/integrations/integrations.controller.ts
@@ -1,0 +1,31 @@
+import express from 'express'
+import { StatusCodes } from 'http-status-codes'
+import { validateRequest } from 'zod-express-middleware'
+import logger from '../../logger'
+import { SituationSchema } from '../simulations/simulations.validator'
+import { exportSituation } from './integrations.service'
+import { SituationExportValidator } from './integrations.validator'
+
+const router = express.Router()
+
+/**
+ * Exports situation to an external Service
+ */
+router
+  .route('/v1/:externalService/export-situation')
+  .post(validateRequest(SituationExportValidator), async (req, res) => {
+    try {
+      const externalServiceRedirection = await exportSituation({
+        externalService: req.params.externalService,
+        situation: SituationSchema.parse(req.body),
+      })
+
+      return res.status(StatusCodes.OK).json(externalServiceRedirection)
+    } catch (err) {
+      logger.error('Situation export failed', err)
+
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
+    }
+  })
+
+export default router

--- a/src/features/integrations/integrations.service.ts
+++ b/src/features/integrations/integrations.service.ts
@@ -1,0 +1,18 @@
+import { exportSituation as agirExportSituation } from '../../adapters/agir/client'
+import type { SituationSchema } from '../simulations/simulations.validator'
+
+const externalServicesMap = {
+  agir: {
+    exportSituation: agirExportSituation,
+  },
+} as const
+
+export const exportSituation = ({
+  externalService,
+  situation,
+}: {
+  situation: SituationSchema
+  externalService: keyof typeof externalServicesMap
+}) => {
+  return externalServicesMap[externalService].exportSituation(situation)
+}

--- a/src/features/integrations/integrations.validator.ts
+++ b/src/features/integrations/integrations.validator.ts
@@ -1,0 +1,16 @@
+import z from 'zod'
+import { SituationSchema } from '../simulations/simulations.validator'
+
+const SituationExportParams = z
+  .object({
+    externalService: z.enum(['agir']),
+  })
+  .strict()
+
+export type SituationExportParams = z.infer<typeof SituationExportParams>
+
+export const SituationExportValidator = {
+  body: SituationSchema,
+  params: SituationExportParams,
+  query: z.object({}).strict().optional(),
+}

--- a/src/features/simulations/__tests__/fixtures/simulations.fixtures.ts
+++ b/src/features/simulations/__tests__/fixtures/simulations.fixtures.ts
@@ -1,0 +1,131 @@
+import { faker } from '@faker-js/faker'
+import type { DottedName, NGCRuleNode } from '@incubateur-ademe/nosgestesclimat'
+import personas from '@incubateur-ademe/nosgestesclimat/public/personas-fr.json'
+import type { ParsedRules, PublicodesExpression } from 'publicodes'
+import { utils } from 'publicodes'
+import { carbonMetric, waterMetric } from '../../../../constants/ngc'
+import { engine } from '../../../../constants/publicode'
+import type { Metric } from '../../../../types/types'
+import type { SituationSchema } from '../../simulations.validator'
+
+const categories = [
+  'transport',
+  'alimentation',
+  'logement',
+  'divers',
+  'services sociétaux',
+] as const
+
+const getSubcategories = ({
+  dottedName,
+  getRule,
+  parsedRules,
+}: {
+  dottedName: DottedName
+  getRule: (dottedName: DottedName) => NGCRuleNode | null
+  parsedRules: Record<string, NGCRuleNode>
+}): DottedName[] => {
+  const ruleNode = getRule(dottedName)
+
+  if (!ruleNode || !ruleNode.rawNode) {
+    return []
+  }
+
+  const dottedNameSomme = ruleNode.rawNode.somme
+
+  const dottedNameFormula = ruleNode.rawNode.formule
+
+  // TO FIX: Sometimes the `somme` isn't in the formula.
+  if (
+    !dottedNameSomme && // No `somme` directly in the rule
+    (!dottedNameFormula ||
+      typeof dottedNameFormula === 'string' ||
+      !Array.isArray(dottedNameFormula.somme)) // No `somme` in the formula or invalid format
+  ) {
+    return []
+  }
+
+  // TODO: Remove this check when the `somme` is always in the formula
+  const sommeArray = Array.isArray(dottedNameSomme)
+    ? dottedNameSomme
+    : typeof dottedNameFormula === 'object' &&
+        Array.isArray(dottedNameFormula.somme)
+      ? dottedNameFormula.somme
+      : []
+
+  return (
+    sommeArray.map(
+      (potentialPartialRuleName: DottedName) =>
+        utils.disambiguateReference(
+          parsedRules,
+          dottedName,
+          potentialPartialRuleName
+        ) as DottedName
+    ) || []
+  )
+}
+
+const evaluate = ({
+  expr,
+  metric,
+}: {
+  expr: PublicodesExpression
+  metric: Metric
+}): number | undefined => {
+  const value = engine.evaluate({
+    valeur: expr,
+    contexte: {
+      métrique: `'${metric}'`,
+    },
+  }).nodeValue
+
+  return typeof value === 'number' ? value : !!value ? +value : undefined
+}
+
+const computeMetricResults = (
+  metric: Metric,
+  parsedRules: ParsedRules<DottedName>
+) => ({
+  bilan: evaluate({ expr: 'bilan', metric }) ?? 0,
+  categories: Object.fromEntries(
+    categories.map((category) => [
+      category,
+      evaluate({ expr: category, metric }) ?? 0,
+    ])
+  ) as Record<(typeof categories)[number], number>,
+  subcategories: Object.fromEntries(
+    categories.flatMap((category) =>
+      getSubcategories({
+        dottedName: category,
+        getRule: (dottedName) => engine.getRule(dottedName),
+        parsedRules,
+      }).map((subcategory) => [
+        subcategory,
+        evaluate({ expr: subcategory, metric }) ?? 0,
+      ])
+    )
+  ),
+})
+
+const getComputedResults = (situation: SituationSchema) => {
+  engine.setSituation(situation)
+
+  const parsedRules = engine.getParsedRules()
+
+  return {
+    carbone: computeMetricResults(carbonMetric, parsedRules),
+    eau: computeMetricResults(waterMetric, parsedRules),
+  }
+}
+
+export const getRandomPersonaSituation = () =>
+  personas[
+    faker.helpers.arrayElement(Object.keys(personas)) as keyof typeof personas
+  ].situation
+
+export const getTestCases = () =>
+  Object.values(personas).map(({ situation, nom }) => ({
+    computedResults: getComputedResults(situation),
+    situation,
+    nom,
+  }))

--- a/src/features/simulations/simulations.validator.ts
+++ b/src/features/simulations/simulations.validator.ts
@@ -1,0 +1,68 @@
+import z from 'zod'
+
+export const SituationSchema = z.record(
+  z.string(),
+  z.union([
+    z.string(),
+    z.number(),
+    z
+      .object({
+        valeur: z.union([
+          z.coerce.number(),
+          z
+            .string()
+            .transform((s) => +s.replace(/\s/g, ''))
+            .pipe(z.coerce.number()),
+        ]),
+        unité: z.string().optional(),
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal('number'),
+        fullPrecision: z.boolean(),
+        nodeValue: z.number(),
+        nodeKind: z.literal('constant'),
+        rawNode: z.number(),
+        isNullable: z.boolean().optional(),
+        missingVariables: z.object({}).optional(),
+      })
+      .strict(),
+    z
+      .object({
+        explanation: z
+          .object({
+            type: z.literal('number'),
+            fullPrecision: z.boolean(),
+            nodeValue: z.number(),
+            nodeKind: z.literal('constant'),
+            rawNode: z
+              .object({
+                constant: z
+                  .object({
+                    type: z.union([z.literal('constant'), z.literal('number')]),
+                    nodeValue: z.number(),
+                  })
+                  .strict(),
+              })
+              .strict(),
+            isNullable: z.boolean().optional(),
+            missingVariables: z.object({}).optional(),
+          })
+          .strict(),
+        unit: z
+          .object({
+            numerators: z.string(),
+            denominators: z.string().optional(),
+          })
+          .strict(),
+        nodeKind: z.literal('unité'),
+        rawNode: z.string(),
+      })
+      .strict(),
+  ])
+)
+
+export type SituationSchemaInput = z.input<typeof SituationSchema>
+
+export type SituationSchema = z.infer<typeof SituationSchema>


### PR DESCRIPTION
```
  Given a NGC user
    When exporting his simulation situation
      And no data provided
        ✓ Then it should return a 400 error
      And invalid external Service
        ✓ Then it should return a 400 error
      And agir external service
        ✓ Then it should return a 200 with a redirectionUrl
        ✓ Then it should send situation on agir service
        And service is down
          ✓ Should retry several times and then raise the exception
          ✓ Should log the exception
```