### PR TITLE
:necktie: API changes for the frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@incubateur-ademe/nosgestesclimat": "^3.1.0",
+    "@incubateur-ademe/nosgestesclimat": "^3.3.4",
     "@prisma/client": "^5.21.1",
     "@publicodes/tools": "^1.2.5",
     "@sentry/node": "^8.26.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "setupFilesAfterEnv": [
       "../jest.setup.ts"
     ],
+    "testTimeout": 10000,
     "testRegex": ".spec.ts$",
     "transform": {
       "^.+\\.(t|j)sx?$": "@swc/jest"

--- a/src/adapters/prisma/selection.ts
+++ b/src/adapters/prisma/selection.ts
@@ -1,0 +1,134 @@
+export const defaultUserSelection = {
+  id: true,
+  name: true,
+  email: true,
+  createdAt: true,
+  updatedAt: true,
+}
+
+export const defaultVerifiedUserSelection = {
+  id: true,
+  name: true,
+  email: true,
+  position: true,
+  telephone: true,
+  optedInForCommunications: true,
+  createdAt: true,
+  updatedAt: true,
+}
+
+export const defaultGroupParticipantSelection = {
+  id: true,
+  user: {
+    select: defaultUserSelection,
+  },
+  simulationId: true,
+  createdAt: true,
+  updatedAt: true,
+}
+
+export const defaultGroupSelectionWithoutParticipants = {
+  id: true,
+  name: true,
+  emoji: true,
+  administrator: {
+    select: {
+      user: {
+        select: defaultUserSelection,
+      },
+    },
+  },
+  updatedAt: true,
+  createdAt: true,
+}
+
+export const defaultGroupSelection = {
+  ...defaultGroupSelectionWithoutParticipants,
+  participants: {
+    select: defaultGroupParticipantSelection,
+  },
+}
+
+export const defaultGroupParticipantSimulationSelection = {
+  id: true,
+  date: true,
+  situation: true,
+  foldedSteps: true,
+  progression: true,
+  actionChoices: true,
+  savedViaEmail: true,
+  computedResults: true,
+  additionalQuestionsAnswers: {
+    select: {
+      key: true,
+      answer: true,
+      type: true,
+    },
+  },
+  polls: {
+    select: {
+      pollId: true,
+      poll: {
+        select: {
+          slug: true,
+        },
+      },
+    },
+  },
+  createdAt: true,
+  updatedAt: true,
+}
+
+export const defaultSimulationSelection = {
+  ...defaultGroupParticipantSimulationSelection,
+  user: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+}
+
+export const defaultOrganisationSelectionWithoutPolls = {
+  id: true,
+  name: true,
+  slug: true,
+  type: true,
+  numberOfCollaborators: true,
+  administrators: {
+    select: {
+      id: true,
+      user: {
+        select: defaultVerifiedUserSelection,
+      },
+    },
+  },
+  createdAt: true,
+  updatedAt: true,
+}
+
+export const defaultOrganisationSelection = {
+  ...defaultOrganisationSelectionWithoutPolls,
+  polls: {
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  },
+}
+
+export const defaultPollSelection = {
+  id: true,
+  name: true,
+  slug: true,
+  organisationId: true,
+  defaultAdditionalQuestions: true,
+  customAdditionalQuestions: true,
+  expectedNumberOfParticipants: true,
+  createdAt: true,
+  updatedAt: true,
+}

--- a/src/adapters/prisma/selection.ts
+++ b/src/adapters/prisma/selection.ts
@@ -79,17 +79,6 @@ export const defaultGroupParticipantSimulationSelection = {
   updatedAt: true,
 }
 
-export const defaultSimulationSelection = {
-  ...defaultGroupParticipantSimulationSelection,
-  user: {
-    select: {
-      id: true,
-      name: true,
-      email: true,
-    },
-  },
-}
-
 export const defaultOrganisationSelectionWithoutPolls = {
   id: true,
   name: true,
@@ -126,9 +115,62 @@ export const defaultPollSelection = {
   name: true,
   slug: true,
   organisationId: true,
+  organisation: {
+    select: defaultOrganisationSelectionWithoutPolls,
+  },
   defaultAdditionalQuestions: true,
   customAdditionalQuestions: true,
   expectedNumberOfParticipants: true,
   createdAt: true,
   updatedAt: true,
+}
+
+export const defaultSimulationSelectionWithoutUserAndPoll = {
+  id: true,
+  date: true,
+  situation: true,
+  foldedSteps: true,
+  progression: true,
+  actionChoices: true,
+  savedViaEmail: true,
+  computedResults: true,
+  additionalQuestionsAnswers: {
+    select: {
+      key: true,
+      answer: true,
+      type: true,
+    },
+  },
+  createdAt: true,
+  updatedAt: true,
+}
+
+export const defaultSimulationSelectionWithoutUser = {
+  ...defaultSimulationSelectionWithoutUserAndPoll,
+  polls: {
+    select: {
+      pollId: true,
+      poll: {
+        select: {
+          slug: true,
+        },
+      },
+    },
+  },
+}
+
+export const defaultSimulationSelectionWithoutPoll = {
+  ...defaultSimulationSelectionWithoutUserAndPoll,
+  user: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+}
+
+export const defaultSimulationSelection = {
+  ...defaultSimulationSelectionWithoutUser,
+  ...defaultSimulationSelectionWithoutPoll,
 }

--- a/src/adapters/prisma/selection.ts
+++ b/src/adapters/prisma/selection.ts
@@ -123,6 +123,21 @@ export const defaultPollSelection = {
   expectedNumberOfParticipants: true,
   createdAt: true,
   updatedAt: true,
+  simulations: {
+    select: {
+      id: true,
+      simulation: {
+        select: {
+          progression: true,
+          user: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+    },
+  },
 }
 
 export const defaultSimulationSelectionWithoutUserAndPoll = {

--- a/src/features/authentication/__tests__/change-device.spec.ts
+++ b/src/features/authentication/__tests__/change-device.spec.ts
@@ -342,7 +342,6 @@ describe('Given a ngc user', () => {
         agent,
         simulation: {
           user: {
-            id: faker.string.uuid(),
             email: faker.internet.email(),
           },
         },
@@ -468,7 +467,6 @@ describe('Given a ngc user', () => {
           agent,
           simulation: {
             user: {
-              id: faker.string.uuid(),
               email,
             },
           },
@@ -627,11 +625,9 @@ describe('Given a ngc user', () => {
       }))
       simulationDevice1 = await createOrganisationPollSimulation({
         agent,
-        organisationId,
         pollId,
         simulation: {
           user: {
-            id: faker.string.uuid(),
             email: faker.internet.email(),
           },
         },
@@ -661,11 +657,9 @@ describe('Given a ngc user', () => {
       beforeEach(async () => {
         simulationDevice2 = await createOrganisationPollSimulation({
           agent,
-          organisationId,
           pollId,
           simulation: {
             user: {
-              id: faker.string.uuid(),
               email,
             },
           },

--- a/src/features/authentication/__tests__/fixtures/login.fixture.ts
+++ b/src/features/authentication/__tests__/fixtures/login.fixture.ts
@@ -31,8 +31,6 @@ export const login = async ({
     })
     .expect(StatusCodes.OK)
 
-  nock.abortPendingRequests()
-
   const [cookie] = response.headers['set-cookie']
 
   return {

--- a/src/features/authentication/__tests__/fixtures/verification-codes.fixture.ts
+++ b/src/features/authentication/__tests__/fixtures/verification-codes.fixture.ts
@@ -47,8 +47,6 @@ export const createVerificationCode = async ({
     .send(payload)
     .expect(StatusCodes.CREATED)
 
-  nock.abortPendingRequests()
-
   jest
     .mocked(authenticationService)
     .generateVerificationCodeAndExpiration.mockRestore()

--- a/src/features/groups/__tests__/fixtures/groups.fixture.ts
+++ b/src/features/groups/__tests__/fixtures/groups.fixture.ts
@@ -54,7 +54,7 @@ export const createGroup = async ({
       .post('/v3/contacts')
       .reply(200)
       .post('/v3/contacts/lists/35/contacts/remove')
-      .reply(200)
+      .reply(400, { code: 'invalid_parameter' })
   }
 
   const response = await agent
@@ -124,7 +124,9 @@ export const joinGroup = async ({
     scope.post('/v3/smtp/email').reply(200).post('/v3/contacts').reply(200)
 
     if (payload.simulation.progression === 1) {
-      scope.post('/v3/contacts/lists/35/contacts/remove').reply(200)
+      scope
+        .post('/v3/contacts/lists/35/contacts/remove')
+        .reply(400, { code: 'invalid_parameter' })
     }
   }
 

--- a/src/features/groups/groups.controller.ts
+++ b/src/features/groups/groups.controller.ts
@@ -104,8 +104,6 @@ router
         return res.status(StatusCodes.NOT_FOUND).send(err.message).end()
       }
 
-      // console.log(err.reasons[0].errors[0])
-
       logger.error('Participant creation failed', err)
 
       return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()

--- a/src/features/groups/groups.repository.ts
+++ b/src/features/groups/groups.repository.ts
@@ -1,4 +1,9 @@
 import { prisma } from '../../adapters/prisma/client'
+import {
+  defaultGroupParticipantSelection,
+  defaultGroupSelection,
+  defaultUserSelection,
+} from '../../adapters/prisma/selection'
 import type { Session } from '../../adapters/prisma/transaction'
 import { transaction } from '../../adapters/prisma/transaction'
 import {
@@ -17,44 +22,6 @@ import {
   type GroupUpdateDto,
   type UserGroupParams,
 } from './groups.validator'
-
-const defaultUserSelection = {
-  select: {
-    id: true,
-    name: true,
-    email: true,
-    createdAt: true,
-    updatedAt: true,
-  },
-}
-
-const defaultParticipantSelection = {
-  id: true,
-  user: defaultUserSelection,
-  simulationId: true,
-  createdAt: true,
-  updatedAt: true,
-}
-
-const groupSelectionWithoutParticipants = {
-  id: true,
-  name: true,
-  emoji: true,
-  administrator: {
-    select: {
-      user: defaultUserSelection,
-    },
-  },
-  updatedAt: true,
-  createdAt: true,
-}
-
-const defaultGroupSelection = {
-  ...groupSelectionWithoutParticipants,
-  participants: {
-    select: defaultParticipantSelection,
-  },
-}
 
 const getParticipantsWithSimulations = <T extends { simulationId: string }>(
   group: {
@@ -245,7 +212,7 @@ export const createParticipantAndUser = async (
           simulationId,
         },
         select: {
-          ...defaultParticipantSelection,
+          ...defaultGroupParticipantSelection,
           group: {
             select: defaultGroupSelection,
           },
@@ -297,7 +264,9 @@ export const deleteParticipantById = async (id: string) => {
       group: {
         select: defaultGroupSelection,
       },
-      user: defaultUserSelection,
+      user: {
+        select: defaultUserSelection,
+      },
     },
   })
 }

--- a/src/features/groups/groups.repository.ts
+++ b/src/features/groups/groups.repository.ts
@@ -318,29 +318,13 @@ export const fetchUserGroups = async (
 }
 
 export const fetchUserGroup = async (
-  { userId, groupId }: UserGroupParams,
+  { groupId }: GroupParams,
   { session }: { session?: Session } = {}
 ) => {
   return transaction(async (prismaSession) => {
     const group = await prismaSession.group.findUniqueOrThrow({
       where: {
         id: groupId,
-        OR: [
-          {
-            administrator: {
-              user: {
-                id: userId,
-              },
-            },
-          },
-          {
-            participants: {
-              some: {
-                userId,
-              },
-            },
-          },
-        ],
       },
       select: defaultGroupSelection,
     })

--- a/src/features/organisations/__tests__/create-organisation-poll.spec.ts
+++ b/src/features/organisations/__tests__/create-organisation-poll.spec.ts
@@ -265,6 +265,11 @@ describe('Given a NGC user', () => {
             expectedNumberOfParticipants: null,
             createdAt: expect.any(String),
             updatedAt: null,
+            simulations: {
+              count: 0,
+              finished: 0,
+              hasParticipated: false,
+            },
           })
         })
 
@@ -404,6 +409,11 @@ describe('Given a NGC user', () => {
               expectedNumberOfParticipants: null,
               createdAt: expect.any(String),
               updatedAt: null,
+              simulations: {
+                count: 0,
+                finished: 0,
+                hasParticipated: false,
+              },
             })
           })
         })
@@ -532,6 +542,11 @@ describe('Given a NGC user', () => {
             expectedNumberOfParticipants: null,
             createdAt: expect.any(String),
             updatedAt: null,
+            simulations: {
+              count: 0,
+              finished: 0,
+              hasParticipated: false,
+            },
           })
 
           jest.spyOn(prisma.organisation, 'update').mockRestore()

--- a/src/features/organisations/__tests__/create-organisation-poll.spec.ts
+++ b/src/features/organisations/__tests__/create-organisation-poll.spec.ts
@@ -208,21 +208,24 @@ describe('Given a NGC user', () => {
       })
 
       describe('And organisation does exist', () => {
+        let organisation: Awaited<ReturnType<typeof createOrganisation>>
+        let _organisationPolls: unknown
         let organisationId: string
         let organisationName: string
         let organisationSlug: string
 
-        beforeEach(
-          async () =>
-            ({
-              id: organisationId,
-              name: organisationName,
-              slug: organisationSlug,
-            } = await createOrganisation({
+        beforeEach(async () => {
+          ;({ polls: _organisationPolls, ...organisation } =
+            await createOrganisation({
               agent,
               cookie,
             }))
-        )
+          ;({
+            id: organisationId,
+            name: organisationName,
+            slug: organisationSlug,
+          } = organisation)
+        })
 
         beforeEach(() => {
           // This is not ideal but prismock does not handle this correctly
@@ -255,6 +258,7 @@ describe('Given a NGC user', () => {
           expect(response.body).toEqual({
             ...payload,
             id: expect.any(String),
+            organisation,
             slug: slugify(payload.name.toLowerCase(), { strict: true }),
             defaultAdditionalQuestions: [],
             customAdditionalQuestions: [],
@@ -392,6 +396,7 @@ describe('Given a NGC user', () => {
 
             expect(response.body).toEqual({
               ...payload,
+              organisation,
               id: expect.any(String),
               slug: slugify(payload.name.toLowerCase(), { strict: true }),
               defaultAdditionalQuestions: [],
@@ -474,14 +479,18 @@ describe('Given a NGC user', () => {
       })
 
       describe('And a poll with the same name already exists in the organisation', () => {
+        let organisation: Awaited<ReturnType<typeof createOrganisation>>
+        let _organisationPolls: unknown
         let organisationId: string
         let name: string
 
         beforeEach(async () => {
-          ;({ id: organisationId } = await createOrganisation({
-            agent,
-            cookie,
-          }))
+          ;({ polls: _organisationPolls, ...organisation } =
+            await createOrganisation({
+              agent,
+              cookie,
+            }))
+          ;({ id: organisationId } = organisation)
           name = faker.company.buzzNoun()
           await createOrganisationPoll({
             agent,
@@ -515,6 +524,7 @@ describe('Given a NGC user', () => {
 
           expect(response.body).toEqual({
             ...payload,
+            organisation,
             id: expect.any(String),
             slug: `${slugify(payload.name.toLowerCase(), { strict: true })}-1`,
             defaultAdditionalQuestions: [],

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll-dashboard.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll-dashboard.spec.ts
@@ -1,0 +1,196 @@
+import { faker } from '@faker-js/faker'
+import { StatusCodes } from 'http-status-codes'
+import supertest from 'supertest'
+import { prisma } from '../../../adapters/prisma/client'
+import app from '../../../app'
+import logger from '../../../logger'
+import { login } from '../../authentication/__tests__/fixtures/login.fixture'
+import {
+  createOrganisation,
+  createOrganisationPoll,
+  createOrganisationPollSimulation,
+  FETCH_ORGANISATION_PUBLIC_POLL_DASHBOARD_ROUTE,
+} from './fixtures/organisations.fixture'
+
+describe('Given a NGC user', () => {
+  const agent = supertest(app)
+  const url = FETCH_ORGANISATION_PUBLIC_POLL_DASHBOARD_ROUTE
+
+  afterEach(() =>
+    Promise.all([
+      prisma.organisation.deleteMany(),
+      prisma.verifiedUser.deleteMany(),
+      prisma.simulation.deleteMany(),
+      prisma.user.deleteMany(),
+      prisma.verificationCode.deleteMany(),
+    ])
+  )
+
+  describe('And logged out', () => {
+    describe('When fetching a public organisation poll dashboard', () => {
+      describe('And invalid userId', () => {
+        test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.alpha(34))
+            )
+            .expect(StatusCodes.BAD_REQUEST)
+        })
+      })
+
+      describe('And poll does not exist', () => {
+        test(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.NOT_FOUND)
+        })
+      })
+
+      describe('And poll does exist', () => {
+        let organisationId: string
+        let pollId: string
+        let pollSlug: string
+
+        beforeEach(async () => {
+          const { cookie } = await login({ agent })
+          ;({ id: organisationId } = await createOrganisation({
+            agent,
+            cookie,
+          }))
+          ;({ id: pollId, slug: pollSlug } = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          }))
+        })
+
+        describe('And he did not participate to the poll', () => {
+          test(`Then it returns a ${StatusCodes.OK} response with the dashboard`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollId)
+                  .replace(':userId', faker.string.uuid())
+              )
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual({
+              funFacts: expect.any(Object),
+            })
+          })
+        })
+
+        describe('And he did participate to the poll', () => {
+          let userId: string
+
+          beforeEach(async () => {
+            ;({
+              user: { id: userId },
+            } = await createOrganisationPollSimulation({
+              agent,
+              organisationId,
+              pollId,
+            }))
+          })
+
+          test(`Then it returns a ${StatusCodes.OK} response with the dashboard`, async () => {
+            const response = await agent
+              .get(
+                url.replace(':pollIdOrSlug', pollId).replace(':userId', userId)
+              )
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual({
+              funFacts: expect.any(Object),
+            })
+          })
+
+          describe('And using poll slug', () => {
+            test(`Then it returns a ${StatusCodes.OK} response with the dashboard`, async () => {
+              const response = await agent
+                .get(
+                  url
+                    .replace(':pollIdOrSlug', pollSlug)
+                    .replace(':userId', userId)
+                )
+                .expect(StatusCodes.OK)
+
+              expect(response.body).toEqual({
+                funFacts: expect.any(Object),
+              })
+            })
+          })
+
+          describe('And another participant joins', () => {
+            beforeEach(async () =>
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              })
+            )
+
+            test(`Then it returns a ${StatusCodes.OK} response with the dashboard`, async () => {
+              const response = await agent
+                .get(
+                  url
+                    .replace(':pollIdOrSlug', pollId)
+                    .replace(':userId', userId)
+                )
+                .expect(StatusCodes.OK)
+
+              expect(response.body).toEqual({
+                funFacts: expect.any(Object),
+              })
+            })
+          })
+        })
+      })
+
+      describe('And database failure', () => {
+        const databaseError = new Error('Something went wrong')
+
+        beforeEach(() => {
+          jest
+            .spyOn(prisma.poll, 'findFirstOrThrow')
+            .mockRejectedValueOnce(databaseError)
+        })
+
+        afterEach(() => {
+          jest.spyOn(prisma.poll, 'findFirstOrThrow').mockRestore()
+        })
+
+        test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        })
+
+        test(`Then it logs the exception`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'Public poll dashboard fetch failed',
+            databaseError
+          )
+        })
+      })
+    })
+  })
+})

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll-dashboard.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll-dashboard.spec.ts
@@ -53,16 +53,15 @@ describe('Given a NGC user', () => {
       })
 
       describe('And poll does exist', () => {
-        let organisationId: string
         let pollId: string
         let pollSlug: string
 
         beforeEach(async () => {
           const { cookie } = await login({ agent })
-          ;({ id: organisationId } = await createOrganisation({
+          const { id: organisationId } = await createOrganisation({
             agent,
             cookie,
-          }))
+          })
           ;({ id: pollId, slug: pollSlug } = await createOrganisationPoll({
             agent,
             cookie,
@@ -94,7 +93,6 @@ describe('Given a NGC user', () => {
               user: { id: userId },
             } = await createOrganisationPollSimulation({
               agent,
-              organisationId,
               pollId,
             }))
           })
@@ -131,7 +129,6 @@ describe('Given a NGC user', () => {
             beforeEach(async () =>
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               })
             )

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll-simulations.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll-simulations.spec.ts
@@ -54,16 +54,15 @@ describe('Given a NGC user', () => {
       })
 
       describe('And poll does exist', () => {
-        let organisationId: string
         let pollId: string
         let pollSlug: string
 
         beforeEach(async () => {
           const { cookie } = await login({ agent })
-          ;({ id: organisationId } = await createOrganisation({
+          const { id: organisationId } = await createOrganisation({
             agent,
             cookie,
-          }))
+          })
           ;({ id: pollId, slug: pollSlug } = await createOrganisationPoll({
             agent,
             cookie,
@@ -96,7 +95,6 @@ describe('Given a NGC user', () => {
             ;({ polls: _simulationPolls, ...simulation } =
               await createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }))
             ;({
@@ -141,7 +139,6 @@ describe('Given a NGC user', () => {
                 ...simulation2
               } = await createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }))
             })
@@ -210,15 +207,14 @@ describe('Given a NGC user', () => {
   describe('And invalid cookie on his organisation space', () => {
     describe('When fetching his organisation public poll simulations', () => {
       describe('And poll does exist', () => {
-        let organisationId: string
         let pollId: string
 
         beforeEach(async () => {
           const { cookie } = await login({ agent })
-          ;({ id: organisationId } = await createOrganisation({
+          const { id: organisationId } = await createOrganisation({
             agent,
             cookie,
-          }))
+          })
           ;({ id: pollId } = await createOrganisationPoll({
             agent,
             cookie,
@@ -243,7 +239,6 @@ describe('Given a NGC user', () => {
           beforeEach(async () =>
             createOrganisationPollSimulation({
               agent,
-              organisationId,
               pollId,
             })
           )
@@ -289,7 +284,6 @@ describe('Given a NGC user', () => {
 
       describe('And poll does exist', () => {
         let organisation: Awaited<ReturnType<typeof createOrganisation>>
-        let organisationId: string
         let poll: Awaited<ReturnType<typeof createOrganisationPoll>>
         let pollId: string
         let pollSlug: string
@@ -299,7 +293,7 @@ describe('Given a NGC user', () => {
             agent,
             cookie,
           })
-          ;({ id: organisationId } = organisation)
+          const { id: organisationId } = organisation
           poll = await createOrganisationPoll({
             agent,
             cookie,
@@ -343,17 +337,14 @@ describe('Given a NGC user', () => {
             simulations = await Promise.all([
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }),
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }),
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }),
             ])

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll-simulations.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll-simulations.spec.ts
@@ -1,0 +1,443 @@
+import { faker } from '@faker-js/faker'
+import { StatusCodes } from 'http-status-codes'
+import supertest from 'supertest'
+import { prisma } from '../../../adapters/prisma/client'
+import app from '../../../app'
+import logger from '../../../logger'
+import { login } from '../../authentication/__tests__/fixtures/login.fixture'
+import { COOKIE_NAME } from '../../authentication/authentication.service'
+import {
+  createOrganisation,
+  createOrganisationPoll,
+  createOrganisationPollSimulation,
+  FETCH_ORGANISATION_PUBLIC_POLL_SIMULATIONS_ROUTE,
+} from './fixtures/organisations.fixture'
+
+describe('Given a NGC user', () => {
+  const agent = supertest(app)
+  const url = FETCH_ORGANISATION_PUBLIC_POLL_SIMULATIONS_ROUTE
+
+  afterEach(() =>
+    Promise.all([
+      prisma.organisation.deleteMany(),
+      prisma.verifiedUser.deleteMany(),
+      prisma.simulation.deleteMany(),
+      prisma.user.deleteMany(),
+      prisma.verificationCode.deleteMany(),
+    ])
+  )
+
+  describe('And logged out', () => {
+    describe('When fetching a public organisation poll simulations', () => {
+      describe('And invalid userId', () => {
+        test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.alpha(34))
+            )
+            .expect(StatusCodes.BAD_REQUEST)
+        })
+      })
+
+      describe('And poll does not exist', () => {
+        test(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.NOT_FOUND)
+        })
+      })
+
+      describe('And poll does exist', () => {
+        let organisationId: string
+        let pollId: string
+        let pollSlug: string
+
+        beforeEach(async () => {
+          const { cookie } = await login({ agent })
+          ;({ id: organisationId } = await createOrganisation({
+            agent,
+            cookie,
+          }))
+          ;({ id: pollId, slug: pollSlug } = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          }))
+        })
+
+        describe('And he did not participate to the poll', () => {
+          test(`Then it returns a ${StatusCodes.OK} response with an empty list`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollId)
+                  .replace(':userId', faker.string.uuid())
+              )
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual([])
+          })
+        })
+
+        describe('And he did participate to the poll', () => {
+          let simulation: Awaited<
+            ReturnType<typeof createOrganisationPollSimulation>
+          >
+          let _simulationPolls: unknown
+          let userId: string
+
+          beforeEach(async () => {
+            ;({ polls: _simulationPolls, ...simulation } =
+              await createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }))
+            ;({
+              user: { id: userId },
+            } = simulation)
+          })
+
+          test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+            const response = await agent
+              .get(
+                url.replace(':pollIdOrSlug', pollId).replace(':userId', userId)
+              )
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual([simulation])
+          })
+
+          describe('And using poll slug', () => {
+            test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+              const response = await agent
+                .get(
+                  url
+                    .replace(':pollIdOrSlug', pollSlug)
+                    .replace(':userId', userId)
+                )
+                .expect(StatusCodes.OK)
+
+              expect(response.body).toEqual([simulation])
+            })
+          })
+
+          describe('And another participant joins', () => {
+            let simulation2: Awaited<
+              ReturnType<typeof createOrganisationPollSimulation>
+            >
+            let _simulationUser: unknown
+
+            beforeEach(async () => {
+              ;({
+                polls: _simulationPolls,
+                user: _simulationUser,
+                ...simulation2
+              } = await createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }))
+            })
+
+            test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+              const response = await agent
+                .get(
+                  url
+                    .replace(':pollIdOrSlug', pollId)
+                    .replace(':userId', userId)
+                )
+                .expect(StatusCodes.OK)
+
+              expect(response.body).toEqual(
+                expect.arrayContaining([
+                  simulation,
+                  { ...simulation2, user: { name: null } },
+                ])
+              )
+            })
+          })
+        })
+      })
+
+      describe('And database failure', () => {
+        const databaseError = new Error('Something went wrong')
+
+        beforeEach(() => {
+          jest
+            .spyOn(prisma.poll, 'findFirstOrThrow')
+            .mockRejectedValueOnce(databaseError)
+        })
+
+        afterEach(() => {
+          jest.spyOn(prisma.poll, 'findFirstOrThrow').mockRestore()
+        })
+
+        test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        })
+
+        test(`Then it logs the exception`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'Public poll simulations fetch failed',
+            databaseError
+          )
+        })
+      })
+    })
+  })
+
+  describe('And invalid cookie on his organisation space', () => {
+    describe('When fetching his organisation public poll simulations', () => {
+      describe('And poll does exist', () => {
+        let organisationId: string
+        let pollId: string
+
+        beforeEach(async () => {
+          const { cookie } = await login({ agent })
+          ;({ id: organisationId } = await createOrganisation({
+            agent,
+            cookie,
+          }))
+          ;({ id: pollId } = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          }))
+        })
+
+        test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+          const response = await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', pollId)
+                .replace(':userId', faker.string.uuid())
+            )
+            .set('cookie', `${COOKIE_NAME}=invalid cookie`)
+            .expect(StatusCodes.OK)
+
+          expect(response.body).toEqual([])
+        })
+
+        describe('And a participant joins', () => {
+          beforeEach(async () =>
+            createOrganisationPollSimulation({
+              agent,
+              organisationId,
+              pollId,
+            })
+          )
+
+          test(`Then it returns a ${StatusCodes.OK} response with an empty list`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollId)
+                  .replace(':userId', faker.string.uuid())
+              )
+              .set('cookie', `${COOKIE_NAME}=invalid cookie`)
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual([])
+          })
+        })
+      })
+    })
+  })
+
+  describe('And logged in on his organisation space', () => {
+    let cookie: string
+    let userId: string
+
+    beforeEach(async () => {
+      ;({ cookie, userId } = await login({ agent }))
+    })
+
+    describe('When fetching his organisation public poll simulations', () => {
+      describe('And poll does not exist', () => {
+        test(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.NOT_FOUND)
+        })
+      })
+
+      describe('And poll does exist', () => {
+        let organisation: Awaited<ReturnType<typeof createOrganisation>>
+        let organisationId: string
+        let poll: Awaited<ReturnType<typeof createOrganisationPoll>>
+        let pollId: string
+        let pollSlug: string
+
+        beforeEach(async () => {
+          organisation = await createOrganisation({
+            agent,
+            cookie,
+          })
+          ;({ id: organisationId } = organisation)
+          poll = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          })
+          ;({ id: pollId, slug: pollSlug } = poll)
+        })
+
+        test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+          const response = await agent
+            .get(
+              url.replace(':pollIdOrSlug', pollId).replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.OK)
+
+          expect(response.body).toEqual([])
+        })
+
+        describe('And using poll slug', () => {
+          test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollSlug)
+                  .replace(':userId', userId)
+              )
+              .set('cookie', cookie)
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual([])
+          })
+        })
+
+        describe('And participants do their simulation', () => {
+          let simulations: Awaited<
+            ReturnType<typeof createOrganisationPollSimulation>
+          >[]
+
+          beforeEach(async () => {
+            simulations = await Promise.all([
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }),
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }),
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }),
+            ])
+          })
+
+          test(`Then it returns a ${StatusCodes.OK} response with the simulations list`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollSlug)
+                  .replace(':userId', userId)
+              )
+              .set('cookie', cookie)
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual(
+              expect.arrayContaining(
+                simulations.map(({ polls: _polls, ...simulation }) => ({
+                  ...simulation,
+                  user: { name: null },
+                }))
+              )
+            )
+          })
+
+          describe('And trying to access user information', () => {
+            test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
+              const [
+                {
+                  user: { id },
+                },
+              ] = simulations
+
+              await agent
+                .get(
+                  url.replace(':pollIdOrSlug', pollId).replace(':userId', id)
+                )
+                .set('cookie', cookie)
+                .expect(StatusCodes.FORBIDDEN)
+            })
+          })
+        })
+      })
+
+      describe('And database failure', () => {
+        const databaseError = new Error('Something went wrong')
+
+        beforeEach(() => {
+          jest
+            .spyOn(prisma.poll, 'findFirstOrThrow')
+            .mockRejectedValueOnce(databaseError)
+        })
+
+        afterEach(() => {
+          jest.spyOn(prisma.poll, 'findFirstOrThrow').mockRestore()
+        })
+
+        test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        })
+
+        test(`Then it logs the exception`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'Public poll simulations fetch failed',
+            databaseError
+          )
+        })
+      })
+    })
+  })
+})

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll.spec.ts
@@ -108,7 +108,6 @@ describe('Given a NGC user', () => {
               user: { id: userId },
             } = await createOrganisationPollSimulation({
               agent,
-              organisationId,
               pollId,
             }))
           })
@@ -278,7 +277,6 @@ describe('Given a NGC user', () => {
 
       describe('And poll does exist', () => {
         let organisation: Awaited<ReturnType<typeof createOrganisation>>
-        let organisationId: string
         let poll: Awaited<ReturnType<typeof createOrganisationPoll>>
         let pollId: string
         let pollSlug: string
@@ -288,7 +286,7 @@ describe('Given a NGC user', () => {
             agent,
             cookie,
           })
-          ;({ id: organisationId } = organisation)
+          const { id: organisationId } = organisation
           poll = await createOrganisationPoll({
             agent,
             cookie,
@@ -342,17 +340,14 @@ describe('Given a NGC user', () => {
             simulations = await Promise.all([
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }),
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }),
               createOrganisationPollSimulation({
                 agent,
-                organisationId,
                 pollId,
               }),
             ])

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll.spec.ts
@@ -127,6 +127,11 @@ describe('Given a NGC user', () => {
                 slug: organisationSlug,
                 name: organisationName,
               },
+              simulations: {
+                count: 1,
+                finished: 1,
+                hasParticipated: true,
+              },
             })
           })
 
@@ -146,6 +151,11 @@ describe('Given a NGC user', () => {
                   id: organisationId,
                   slug: organisationSlug,
                   name: organisationName,
+                },
+                simulations: {
+                  count: 1,
+                  finished: 1,
+                  hasParticipated: true,
                 },
               })
             })
@@ -363,6 +373,11 @@ describe('Given a NGC user', () => {
             expect(response.body).toEqual({
               ...poll,
               organisation: expectedOrganisation,
+              simulations: {
+                count: 3,
+                finished: 3,
+                hasParticipated: false,
+              },
             })
           })
 

--- a/src/features/organisations/__tests__/fetch-organisation-public-poll.spec.ts
+++ b/src/features/organisations/__tests__/fetch-organisation-public-poll.spec.ts
@@ -1,0 +1,430 @@
+import { faker } from '@faker-js/faker'
+import { StatusCodes } from 'http-status-codes'
+import supertest from 'supertest'
+import { prisma } from '../../../adapters/prisma/client'
+import app from '../../../app'
+import logger from '../../../logger'
+import { login } from '../../authentication/__tests__/fixtures/login.fixture'
+import { COOKIE_NAME } from '../../authentication/authentication.service'
+import {
+  createOrganisation,
+  createOrganisationPoll,
+  createOrganisationPollSimulation,
+  FETCH_ORGANISATION_PUBLIC_POLL_ROUTE,
+} from './fixtures/organisations.fixture'
+
+describe('Given a NGC user', () => {
+  const agent = supertest(app)
+  const url = FETCH_ORGANISATION_PUBLIC_POLL_ROUTE
+
+  afterEach(() =>
+    Promise.all([
+      prisma.organisation.deleteMany(),
+      prisma.verifiedUser.deleteMany(),
+      prisma.simulation.deleteMany(),
+      prisma.user.deleteMany(),
+      prisma.verificationCode.deleteMany(),
+    ])
+  )
+
+  describe('And logged out', () => {
+    describe('When fetching a public organisation poll', () => {
+      describe('And invalid userId', () => {
+        test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.alpha(34))
+            )
+            .expect(StatusCodes.BAD_REQUEST)
+        })
+      })
+
+      describe('And poll does not exist', () => {
+        test(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.NOT_FOUND)
+        })
+      })
+
+      describe('And poll does exist', () => {
+        let organisationId: string
+        let organisationName: string
+        let organisationSlug: string
+        let poll: Awaited<ReturnType<typeof createOrganisationPoll>>
+        let pollId: string
+        let pollSlug: string
+
+        beforeEach(async () => {
+          const { cookie } = await login({ agent })
+          ;({
+            id: organisationId,
+            slug: organisationSlug,
+            name: organisationName,
+          } = await createOrganisation({
+            agent,
+            cookie,
+          }))
+          poll = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          })
+          ;({ id: pollId, slug: pollSlug } = poll)
+        })
+
+        describe('And he did not participate to the poll', () => {
+          test(`Then it returns a ${StatusCodes.OK} response with the poll data`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollId)
+                  .replace(':userId', faker.string.uuid())
+              )
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual({
+              ...poll,
+              organisation: {
+                id: organisationId,
+                slug: organisationSlug,
+                name: organisationName,
+              },
+            })
+          })
+        })
+
+        describe('And he did participate to the poll', () => {
+          let userId: string
+
+          beforeEach(async () => {
+            ;({
+              user: { id: userId },
+            } = await createOrganisationPollSimulation({
+              agent,
+              organisationId,
+              pollId,
+            }))
+          })
+
+          test(`Then it returns a ${StatusCodes.OK} response with the poll data`, async () => {
+            const response = await agent
+              .get(
+                url.replace(':pollIdOrSlug', pollId).replace(':userId', userId)
+              )
+              .expect(StatusCodes.OK)
+
+            expect(response.body).toEqual({
+              ...poll,
+              organisation: {
+                id: organisationId,
+                slug: organisationSlug,
+                name: organisationName,
+              },
+            })
+          })
+
+          describe('And using poll slug', () => {
+            test(`Then it returns a ${StatusCodes.OK} response with the poll data`, async () => {
+              const response = await agent
+                .get(
+                  url
+                    .replace(':pollIdOrSlug', pollSlug)
+                    .replace(':userId', userId)
+                )
+                .expect(StatusCodes.OK)
+
+              expect(response.body).toEqual({
+                ...poll,
+                organisation: {
+                  id: organisationId,
+                  slug: organisationSlug,
+                  name: organisationName,
+                },
+              })
+            })
+          })
+        })
+      })
+
+      describe('And database failure', () => {
+        const databaseError = new Error('Something went wrong')
+
+        beforeEach(() => {
+          jest
+            .spyOn(prisma.poll, 'findFirstOrThrow')
+            .mockRejectedValueOnce(databaseError)
+        })
+
+        afterEach(() => {
+          jest.spyOn(prisma.poll, 'findFirstOrThrow').mockRestore()
+        })
+
+        test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        })
+
+        test(`Then it logs the exception`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', faker.string.uuid())
+            )
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'Public poll fetch failed',
+            databaseError
+          )
+        })
+      })
+    })
+  })
+
+  describe('And invalid cookie on his organisation space', () => {
+    describe('When fetching his organisation public poll', () => {
+      describe('And poll does exist', () => {
+        let userId: string
+        let organisationId: string
+        let organisationName: string
+        let organisationSlug: string
+        let poll: Awaited<ReturnType<typeof createOrganisationPoll>>
+        let pollId: string
+
+        beforeEach(async () => {
+          let cookie: string
+          ;({ cookie, userId } = await login({ agent }))
+          ;({
+            id: organisationId,
+            slug: organisationSlug,
+            name: organisationName,
+          } = await createOrganisation({
+            agent,
+            cookie,
+          }))
+          poll = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          })
+          ;({ id: pollId } = poll)
+        })
+
+        test(`Then it returns a ${StatusCodes.OK} response with the public poll data`, async () => {
+          const response = await agent
+            .get(
+              url.replace(':pollIdOrSlug', pollId).replace(':userId', userId)
+            )
+            .set('cookie', `${COOKIE_NAME}=invalid cookie`)
+            .expect(StatusCodes.OK)
+
+          expect(response.body).toEqual({
+            ...poll,
+            organisation: {
+              id: organisationId,
+              slug: organisationSlug,
+              name: organisationName,
+            },
+          })
+        })
+      })
+    })
+  })
+
+  describe('And logged in on his organisation space', () => {
+    let cookie: string
+    let userId: string
+
+    beforeEach(async () => {
+      ;({ cookie, userId } = await login({ agent }))
+    })
+
+    describe('When fetching his organisation public poll', () => {
+      describe('And poll does not exist', () => {
+        test(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.NOT_FOUND)
+        })
+      })
+
+      describe('And poll does exist', () => {
+        let organisation: Awaited<ReturnType<typeof createOrganisation>>
+        let organisationId: string
+        let poll: Awaited<ReturnType<typeof createOrganisationPoll>>
+        let pollId: string
+        let pollSlug: string
+
+        beforeEach(async () => {
+          organisation = await createOrganisation({
+            agent,
+            cookie,
+          })
+          ;({ id: organisationId } = organisation)
+          poll = await createOrganisationPoll({
+            agent,
+            cookie,
+            organisationId,
+          })
+          ;({ id: pollId, slug: pollSlug } = poll)
+        })
+
+        test(`Then it returns a ${StatusCodes.OK} response with the private poll data`, async () => {
+          const response = await agent
+            .get(
+              url.replace(':pollIdOrSlug', pollId).replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.OK)
+
+          const { polls: _, ...expectedOrganisation } = organisation
+
+          expect(response.body).toEqual({
+            ...poll,
+            organisation: expectedOrganisation,
+          })
+        })
+
+        describe('And using poll slug', () => {
+          test(`Then it returns a ${StatusCodes.OK} response with the private poll data`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollSlug)
+                  .replace(':userId', userId)
+              )
+              .set('cookie', cookie)
+              .expect(StatusCodes.OK)
+
+            const { polls: _, ...expectedOrganisation } = organisation
+
+            expect(response.body).toEqual({
+              ...poll,
+              organisation: expectedOrganisation,
+            })
+          })
+        })
+
+        describe('And participants do their simulation', () => {
+          let simulations: Awaited<
+            ReturnType<typeof createOrganisationPollSimulation>
+          >[]
+
+          beforeEach(async () => {
+            simulations = await Promise.all([
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }),
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }),
+              createOrganisationPollSimulation({
+                agent,
+                organisationId,
+                pollId,
+              }),
+            ])
+          })
+
+          test(`Then it returns a ${StatusCodes.OK} response with the private poll data`, async () => {
+            const response = await agent
+              .get(
+                url
+                  .replace(':pollIdOrSlug', pollSlug)
+                  .replace(':userId', userId)
+              )
+              .set('cookie', cookie)
+              .expect(StatusCodes.OK)
+
+            const { polls: _, ...expectedOrganisation } = organisation
+
+            expect(response.body).toEqual({
+              ...poll,
+              organisation: expectedOrganisation,
+            })
+          })
+
+          describe('And trying to access user information', () => {
+            test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
+              const [
+                {
+                  user: { id },
+                },
+              ] = simulations
+
+              await agent
+                .get(
+                  url.replace(':pollIdOrSlug', pollId).replace(':userId', id)
+                )
+                .set('cookie', cookie)
+                .expect(StatusCodes.FORBIDDEN)
+            })
+          })
+        })
+      })
+
+      describe('And database failure', () => {
+        const databaseError = new Error('Something went wrong')
+
+        beforeEach(() => {
+          jest
+            .spyOn(prisma.poll, 'findFirstOrThrow')
+            .mockRejectedValueOnce(databaseError)
+        })
+
+        afterEach(() => {
+          jest.spyOn(prisma.poll, 'findFirstOrThrow').mockRestore()
+        })
+
+        test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} error`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        })
+
+        test(`Then it logs the exception`, async () => {
+          await agent
+            .get(
+              url
+                .replace(':pollIdOrSlug', faker.database.mongodbObjectId())
+                .replace(':userId', userId)
+            )
+            .set('cookie', cookie)
+            .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'Public poll fetch failed',
+            databaseError
+          )
+        })
+      })
+    })
+  })
+})

--- a/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
+++ b/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
@@ -50,6 +50,9 @@ export const FETCH_ORGANISATION_PUBLIC_POLL_ROUTE =
 export const FETCH_ORGANISATION_PUBLIC_POLL_SIMULATIONS_ROUTE =
   '/organisations/v1/:userId/public-polls/:pollIdOrSlug/simulations'
 
+export const FETCH_ORGANISATION_PUBLIC_POLL_DASHBOARD_ROUTE =
+  '/organisations/v1/:userId/public-polls/:pollIdOrSlug/dashboard'
+
 export const CREATE_POLL_SIMULATION_ROUTE =
   '/organisations/v1/:organisationIdOrSlug/polls/:pollIdOrSlug/simulations'
 

--- a/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
+++ b/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
@@ -283,6 +283,13 @@ export const createOrganisationPoll = async ({
     defaultAdditionalQuestions: poll.defaultAdditionalQuestions.map(
       ({ type }) => type
     ),
+    simulations: {
+      count: poll.simulations.length,
+      finished: poll.simulations.filter(
+        ({ simulation: { progression } }) => progression === 1
+      ).length,
+      hasParticipated: false,
+    },
   }
 }
 

--- a/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
+++ b/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
@@ -6,12 +6,12 @@ import nock from 'nock'
 import slugify from 'slugify'
 import { baseURL } from '../../../../adapters/connect/client'
 import { prisma } from '../../../../adapters/prisma/client'
+import {
+  defaultOrganisationSelectionWithoutPolls,
+  defaultPollSelection,
+} from '../../../../adapters/prisma/selection'
 import { getSimulationPayload } from '../../../simulations/__tests__/fixtures/simulations.fixtures'
 import type { SimulationCreateInputDto } from '../../../simulations/simulations.validator'
-import {
-  defaultPollSelection,
-  organisationSelectionWithoutPolls,
-} from '../../organisations.repository'
 import type {
   OrganisationCreateDto,
   OrganisationPollCreateDto,
@@ -130,7 +130,7 @@ export const mockUpdateOrganisationPollCreation: any = async (params: any) => {
       id,
     },
     select: {
-      ...organisationSelectionWithoutPolls,
+      ...defaultOrganisationSelectionWithoutPolls,
       polls: {
         where: {
           slug: create.slug!,

--- a/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
+++ b/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
@@ -47,6 +47,9 @@ export const FETCH_ORGANISATION_POLL_ROUTE =
 export const FETCH_ORGANISATION_PUBLIC_POLL_ROUTE =
   '/organisations/v1/:userId/public-polls/:pollIdOrSlug'
 
+export const FETCH_ORGANISATION_PUBLIC_POLL_SIMULATIONS_ROUTE =
+  '/organisations/v1/:userId/public-polls/:pollIdOrSlug/simulations'
+
 export const CREATE_POLL_SIMULATION_ROUTE =
   '/organisations/v1/:organisationIdOrSlug/polls/:pollIdOrSlug/simulations'
 

--- a/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
+++ b/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
@@ -97,8 +97,6 @@ export const createOrganisation = async ({
     .send(payload)
     .expect(StatusCodes.CREATED)
 
-  nock.abortPendingRequests()
-
   return response.body
 }
 

--- a/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
+++ b/src/features/organisations/__tests__/fixtures/organisations.fixture.ts
@@ -96,7 +96,9 @@ export const createOrganisation = async ({
   const [administrator] = administrators || []
 
   if (!administrator?.optedInForCommunications) {
-    scope.post('/v3/contacts/lists/27/contacts/remove').reply(200)
+    scope
+      .post('/v3/contacts/lists/27/contacts/remove')
+      .reply(400, { code: 'invalid_parameter' })
   }
 
   nock(baseURL).post('/api/v1/personnes').reply(200)
@@ -321,7 +323,7 @@ export const createOrganisationPollSimulation = async ({
     .post('/v3/contacts')
     .reply(200)
     .post('/v3/contacts/lists/27/contacts/remove')
-    .reply(200)
+    .reply(400, { code: 'invalid_parameter' })
 
   if (payload.user?.email) {
     scope
@@ -330,7 +332,7 @@ export const createOrganisationPollSimulation = async ({
       .post('/v3/contacts')
       .reply(200)
       .post('/v3/contacts/lists/35/contacts/remove')
-      .reply(200)
+      .reply(400, { code: 'invalid_parameter' })
   }
 
   const response = await agent

--- a/src/features/organisations/organisations.controller.ts
+++ b/src/features/organisations/organisations.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '../authentication/authentication.service'
 import {
   createPollSimulation,
+  fetchPublicPollDashboard,
   fetchPublicPollSimulations,
 } from '../simulations/simulations.service'
 import {
@@ -47,6 +48,7 @@ import {
   OrganisationPollFetchValidator,
   OrganisationPollsFetchValidator,
   OrganisationPollUpdateValidator,
+  OrganisationPublicPollDashboardValidator,
   OrganisationPublicPollFetchValidator,
   OrganisationPublicPollSimulationsFetchValidator,
   OrganisationsFetchValidator,
@@ -411,6 +413,30 @@ router
         }
 
         logger.error('Public poll simulations fetch failed', err)
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
+      }
+    }
+  )
+
+/**
+ * Returns poll dashboard for public or administrator users following authentication
+ */
+router
+  .route('/v1/:userId/public-polls/:pollIdOrSlug/dashboard')
+  .get(
+    validateRequest(OrganisationPublicPollDashboardValidator),
+    async (req, res) => {
+      try {
+        const dashboard = await fetchPublicPollDashboard(req)
+
+        return res.status(StatusCodes.OK).json(dashboard)
+      } catch (err) {
+        if (err instanceof EntityNotFoundException) {
+          return res.status(StatusCodes.NOT_FOUND).send(err.message).end()
+        }
+
+        logger.error('Public poll dashboard fetch failed', err)
 
         return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
       }

--- a/src/features/organisations/organisations.controller.ts
+++ b/src/features/organisations/organisations.controller.ts
@@ -329,7 +329,7 @@ router
  * Upserts simulation poll for an organisation and an id or a slug
  */
 router
-  .route('/v1/:organisationIdOrSlug/polls/:pollIdOrSlug/simulations')
+  .route('/v1/:userId/public-polls/:pollIdOrSlug/simulations')
   .post(
     validateRequest(OrganisationPollSimulationCreateValidator),
     async (req, res) => {

--- a/src/features/organisations/organisations.repository.ts
+++ b/src/features/organisations/organisations.repository.ts
@@ -315,7 +315,7 @@ export const createOrganisationPoll = async (
     name,
     expectedNumberOfParticipants,
     defaultAdditionalQuestions,
-    customAdditionalQuestions = [],
+    customAdditionalQuestions,
   }: OrganisationPollCreateDto,
   user: NonNullable<Request['user']>,
   { session }: { session?: Session } = {}
@@ -333,7 +333,7 @@ export const createOrganisationPoll = async (
           create: {
             slug,
             name,
-            customAdditionalQuestions,
+            customAdditionalQuestions: customAdditionalQuestions ?? [],
             expectedNumberOfParticipants,
             ...(!!defaultAdditionalQuestions?.length
               ? {

--- a/src/features/organisations/organisations.repository.ts
+++ b/src/features/organisations/organisations.repository.ts
@@ -410,12 +410,7 @@ export const updateOrganisationPoll = async (
             }
           : {}),
       },
-      select: {
-        ...defaultPollSelection,
-        organisation: {
-          select: defaultOrganisationSelectionWithoutPolls,
-        },
-      },
+      select: defaultPollSelection,
     })
   }, session)
 }
@@ -465,7 +460,11 @@ export const fetchOrganisationPoll = (
   user: NonNullable<Request['user']>
 ) => {
   return findOrganisationPollBySlugOrId(
-    { params, user, select: defaultPollSelection },
+    {
+      params,
+      user,
+      select: defaultPollSelection,
+    },
     { session: prisma }
   )
 }

--- a/src/features/organisations/organisations.repository.ts
+++ b/src/features/organisations/organisations.repository.ts
@@ -110,6 +110,26 @@ const findOrganisationPollBySlugOrId = <
   })
 }
 
+export const findOrganisationPublicPollBySlugOrId = <
+  T extends Prisma.PollSelect = { id: true },
+>(
+  {
+    params: { pollIdOrSlug },
+    select = { id: true } as T,
+  }: {
+    params: PollParams
+    select?: T
+  },
+  { session }: { session: Session }
+) => {
+  return session.poll.findFirstOrThrow({
+    where: {
+      OR: [{ id: pollIdOrSlug }, { slug: pollIdOrSlug }],
+    },
+    select,
+  })
+}
+
 const findUniqueOrganisationSlug = findModelUniqueSlug('organisation')
 
 export const createOrganisationAndAdministrator = async (

--- a/src/features/organisations/organisations.repository.ts
+++ b/src/features/organisations/organisations.repository.ts
@@ -17,6 +17,7 @@ import type {
   OrganisationPollParams,
   OrganisationPollUpdateDto,
   OrganisationUpdateDto,
+  PollParams,
 } from './organisations.validator'
 
 const findModelUniqueSlug = (model: 'organisation' | 'poll') => {
@@ -467,6 +468,22 @@ export const fetchOrganisationPoll = (
     },
     { session: prisma }
   )
+}
+
+export const fetchOrganisationPublicPoll = ({ pollIdOrSlug }: PollParams) => {
+  return prisma.poll.findFirstOrThrow({
+    where: {
+      OR: [
+        {
+          id: pollIdOrSlug,
+        },
+        {
+          slug: pollIdOrSlug,
+        },
+      ],
+    },
+    select: defaultPollSelection,
+  })
 }
 
 export const getLastPollParticipantsCount = async (organisationId: string) => {

--- a/src/features/organisations/organisations.repository.ts
+++ b/src/features/organisations/organisations.repository.ts
@@ -2,6 +2,12 @@ import type { Prisma } from '@prisma/client'
 import type { Request } from 'express'
 import slugify from 'slugify'
 import { prisma } from '../../adapters/prisma/client'
+import {
+  defaultOrganisationSelection,
+  defaultOrganisationSelectionWithoutPolls,
+  defaultPollSelection,
+  defaultVerifiedUserSelection,
+} from '../../adapters/prisma/selection'
 import type { Session } from '../../adapters/prisma/transaction'
 import { transaction } from '../../adapters/prisma/transaction'
 import type {
@@ -12,48 +18,6 @@ import type {
   OrganisationPollUpdateDto,
   OrganisationUpdateDto,
 } from './organisations.validator'
-
-const defaultUserSelection = {
-  select: {
-    id: true,
-    name: true,
-    email: true,
-    position: true,
-    telephone: true,
-    optedInForCommunications: true,
-    createdAt: true,
-    updatedAt: true,
-  },
-}
-
-export const organisationSelectionWithoutPolls = {
-  id: true,
-  name: true,
-  slug: true,
-  type: true,
-  numberOfCollaborators: true,
-  administrators: {
-    select: {
-      id: true,
-      user: defaultUserSelection,
-    },
-  },
-  createdAt: true,
-  updatedAt: true,
-}
-
-const defaultOrganisationSelection = {
-  ...organisationSelectionWithoutPolls,
-  polls: {
-    select: {
-      id: true,
-      name: true,
-      slug: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  },
-}
 
 const findModelUniqueSlug = (model: 'organisation' | 'poll') => {
   const findUniqueSlug = async (
@@ -185,7 +149,7 @@ export const createOrganisationAndAdministrator = async (
         telephone,
         optedInForCommunications,
       },
-      ...defaultUserSelection,
+      select: defaultVerifiedUserSelection,
     })
 
     const slug = await findUniqueOrganisationSlug(name, {
@@ -268,7 +232,7 @@ export const updateAdministratorOrganisation = async (
           telephone,
           optedInForCommunications,
         },
-        ...defaultUserSelection,
+        select: defaultVerifiedUserSelection,
       })
 
       if (email) {
@@ -320,18 +284,6 @@ export const fetchUserOrganisation = (
     },
     { session: prisma }
   )
-}
-
-export const defaultPollSelection = {
-  id: true,
-  name: true,
-  slug: true,
-  organisationId: true,
-  defaultAdditionalQuestions: true,
-  customAdditionalQuestions: true,
-  expectedNumberOfParticipants: true,
-  createdAt: true,
-  updatedAt: true,
 }
 
 const findUniquePollSlug = findModelUniqueSlug('poll')
@@ -461,7 +413,7 @@ export const updateOrganisationPoll = async (
       select: {
         ...defaultPollSelection,
         organisation: {
-          select: organisationSelectionWithoutPolls,
+          select: defaultOrganisationSelectionWithoutPolls,
         },
       },
     })
@@ -481,7 +433,7 @@ export const deleteOrganisationPoll = async (
       ),
       select: {
         organisation: {
-          select: organisationSelectionWithoutPolls,
+          select: defaultOrganisationSelectionWithoutPolls,
         },
       },
     })

--- a/src/features/organisations/organisations.service.ts
+++ b/src/features/organisations/organisations.service.ts
@@ -19,6 +19,7 @@ import {
   deleteOrganisationPoll,
   fetchOrganisationPoll,
   fetchOrganisationPolls,
+  fetchOrganisationPublicPoll,
   fetchUserOrganisation,
   fetchUserOrganisations,
   updateAdministratorOrganisation,
@@ -31,6 +32,7 @@ import type {
   OrganisationPollParams,
   OrganisationPollUpdateDto,
   OrganisationUpdateDto,
+  PollParams,
 } from './organisations.validator'
 
 const organisationToDto = (
@@ -340,6 +342,28 @@ export const fetchPoll = async ({
     const poll = await fetchOrganisationPoll(params, user)
 
     return pollToDto({ poll, user })
+  } catch (e) {
+    if (isPrismaErrorNotFound(e)) {
+      throw new EntityNotFoundException('Poll not found')
+    }
+    throw e
+  }
+}
+
+export const fetchPublicPoll = async ({
+  params,
+  user,
+}: {
+  params: PollParams
+  user?: NonNullable<Request['user']>
+}) => {
+  try {
+    const poll = await fetchOrganisationPublicPoll(params)
+
+    return pollToDto({
+      poll,
+      user,
+    })
   } catch (e) {
     if (isPrismaErrorNotFound(e)) {
       throw new EntityNotFoundException('Poll not found')

--- a/src/features/organisations/organisations.service.ts
+++ b/src/features/organisations/organisations.service.ts
@@ -31,8 +31,8 @@ import type {
   OrganisationPollCreateDto,
   OrganisationPollParams,
   OrganisationPollUpdateDto,
-  OrganisationPublicPollParams,
   OrganisationUpdateDto,
+  PublicPollParams,
 } from './organisations.validator'
 
 const organisationToDto = (
@@ -369,7 +369,7 @@ export const fetchPublicPoll = async ({
   params,
   user,
 }: {
-  params: OrganisationPublicPollParams
+  params: PublicPollParams
   user?: NonNullable<Request['user']>
 }) => {
   try {

--- a/src/features/organisations/organisations.validator.ts
+++ b/src/features/organisations/organisations.validator.ts
@@ -217,3 +217,9 @@ export const OrganisationPublicPollSimulationsFetchValidator = {
   params: PublicPollParams,
   query: z.object({}).strict().optional(),
 }
+
+export const OrganisationPublicPollDashboardValidator = {
+  body: z.object({}).strict().optional(),
+  params: PublicPollParams,
+  query: z.object({}).strict().optional(),
+}

--- a/src/features/organisations/organisations.validator.ts
+++ b/src/features/organisations/organisations.validator.ts
@@ -48,9 +48,9 @@ const OrganisationType = z.enum([
 
 const OrganisationCreateAdministrator = z
   .object({
-    name: z.string().optional(),
-    telephone: z.string().optional(),
-    position: z.string().optional(),
+    name: z.string().optional().nullable(),
+    telephone: z.string().optional().nullable(),
+    position: z.string().optional().nullable(),
     optedInForCommunications: z.boolean().optional(),
   })
   .strict()
@@ -62,9 +62,9 @@ export type OrganisationCreateAdministrator = z.infer<
 const OrganisationCreateDto = z
   .object({
     name: z.string().min(1).max(100),
-    type: OrganisationType,
+    type: OrganisationType.optional().nullable(),
     administrators: z.tuple([OrganisationCreateAdministrator]).optional(),
-    numberOfCollaborators: z.number().optional(),
+    numberOfCollaborators: z.number().optional().nullable(),
   })
   .strict()
 
@@ -150,7 +150,7 @@ const MAX_CUSTOM_ADDITIONAL_QUESTIONS = 4
 const OrganisationPollCreateDto = z
   .object({
     name: z.string().min(1).max(150),
-    expectedNumberOfParticipants: z.number().optional(),
+    expectedNumberOfParticipants: z.number().optional().nullable(),
     defaultAdditionalQuestions: z
       .array(
         z.enum([
@@ -158,11 +158,13 @@ const OrganisationPollCreateDto = z
           PollDefaultAdditionalQuestionTypeEnum.postalCode,
         ])
       )
-      .optional(),
+      .optional()
+      .nullable(),
     customAdditionalQuestions: z
       .array(OrganisationPollCreateCustomAdditionalQuestion)
       .max(MAX_CUSTOM_ADDITIONAL_QUESTIONS)
-      .optional(),
+      .optional()
+      .nullable(),
   })
   .strict()
 

--- a/src/features/organisations/organisations.validator.ts
+++ b/src/features/organisations/organisations.validator.ts
@@ -1,5 +1,6 @@
 import z from 'zod'
 import { EMAIL_REGEX } from '../../core/typeguards/isValidEmail'
+import { UserParams } from '../users/users.validator'
 
 const OrganisationParams = z
   .object({
@@ -20,6 +21,12 @@ export type PollParams = z.infer<typeof PollParams>
 export const OrganisationPollParams = OrganisationParams.merge(PollParams)
 
 export type OrganisationPollParams = z.infer<typeof OrganisationPollParams>
+
+export const OrganisationPublicPollParams = UserParams.merge(PollParams)
+
+export type OrganisationPublicPollParams = z.infer<
+  typeof OrganisationPublicPollParams
+>
 
 export enum OrganisationTypeEnum {
   association = 'association',
@@ -198,5 +205,11 @@ export const OrganisationPollsFetchValidator = {
 export const OrganisationPollFetchValidator = {
   body: z.object({}).strict().optional(),
   params: OrganisationPollParams,
+  query: z.object({}).strict().optional(),
+}
+
+export const OrganisationPublicPollFetchValidator = {
+  body: z.object({}).strict().optional(),
+  params: OrganisationPublicPollParams,
   query: z.object({}).strict().optional(),
 }

--- a/src/features/organisations/organisations.validator.ts
+++ b/src/features/organisations/organisations.validator.ts
@@ -22,11 +22,9 @@ export const OrganisationPollParams = OrganisationParams.merge(PollParams)
 
 export type OrganisationPollParams = z.infer<typeof OrganisationPollParams>
 
-export const OrganisationPublicPollParams = UserParams.merge(PollParams)
+export const PublicPollParams = UserParams.merge(PollParams)
 
-export type OrganisationPublicPollParams = z.infer<
-  typeof OrganisationPublicPollParams
->
+export type PublicPollParams = z.infer<typeof PublicPollParams>
 
 export enum OrganisationTypeEnum {
   association = 'association',
@@ -210,6 +208,12 @@ export const OrganisationPollFetchValidator = {
 
 export const OrganisationPublicPollFetchValidator = {
   body: z.object({}).strict().optional(),
-  params: OrganisationPublicPollParams,
+  params: PublicPollParams,
+  query: z.object({}).strict().optional(),
+}
+
+export const OrganisationPublicPollSimulationsFetchValidator = {
+  body: z.object({}).strict().optional(),
+  params: PublicPollParams,
   query: z.object({}).strict().optional(),
 }

--- a/src/features/simulations/__tests__/fixtures/simulations.fixtures.ts
+++ b/src/features/simulations/__tests__/fixtures/simulations.fixtures.ts
@@ -202,13 +202,13 @@ export const createSimulation = async ({
       .post('/v3/contacts')
       .reply(200)
       .post('/v3/contacts/lists/22/contacts/remove')
-      .reply(200)
+      .reply(400, { code: 'invalid_parameter' })
       .post('/v3/contacts/lists/32/contacts/remove')
-      .reply(200)
+      .reply(400, { code: 'invalid_parameter' })
       .post('/v3/contacts/lists/35/contacts/remove')
-      .reply(200)
+      .reply(400, { code: 'invalid_parameter' })
       .post('/v3/contacts/lists/36/contacts/remove')
-      .reply(200)
+      .reply(400, { code: 'invalid_parameter' })
 
     if (payload.progression === 1) {
       scope.post('/v3/smtp/email').reply(200)

--- a/src/features/simulations/simulations.controller.ts
+++ b/src/features/simulations/simulations.controller.ts
@@ -33,7 +33,7 @@ EventBus.on(SimulationUpsertedEvent, syncUserDataAfterSimulationUpserted)
  * Upserts a simulation
  */
 router
-  .route('/v1/')
+  .route('/v1/:userId')
   .post(validateRequest(SimulationCreateValidator), async (req, res) => {
     try {
       const simulation = await createSimulation({
@@ -41,6 +41,7 @@ router
         newsletters: SimulationCreateNewsletterList.parse(
           req.query?.newsletters || []
         ),
+        params: req.params,
         origin: req.get('origin') || config.origin,
       })
 

--- a/src/features/simulations/simulations.repository.ts
+++ b/src/features/simulations/simulations.repository.ts
@@ -1,10 +1,10 @@
 import type { Prisma } from '@prisma/client'
 import { prisma } from '../../adapters/prisma/client'
 import {
-  defaultGroupParticipantSimulationSelection,
   defaultOrganisationSelectionWithoutPolls,
   defaultPollSelection,
   defaultSimulationSelection,
+  defaultSimulationSelectionWithoutUser,
 } from '../../adapters/prisma/selection'
 import type { Session } from '../../adapters/prisma/transaction'
 import { transaction } from '../../adapters/prisma/transaction'
@@ -58,7 +58,7 @@ export const createUserSimulation = (
 
 export const createParticipantSimulation = <
   T extends
-    Prisma.SimulationSelect = typeof defaultGroupParticipantSimulationSelection,
+    Prisma.SimulationSelect = typeof defaultSimulationSelectionWithoutUser,
 >(
   {
     userId,
@@ -73,7 +73,7 @@ export const createParticipantSimulation = <
       savedViaEmail,
       additionalQuestionsAnswers,
     },
-    select = defaultGroupParticipantSimulationSelection as T,
+    select = defaultSimulationSelectionWithoutUser as T,
   }: {
     userId: string
     simulation: SimulationParticipantCreateDto
@@ -174,7 +174,7 @@ export const fetchParticipantSimulation = (
     where: {
       id: simulationId,
     },
-    select: defaultGroupParticipantSimulationSelection,
+    select: defaultSimulationSelectionWithoutUser,
   })
 }
 

--- a/src/features/simulations/simulations.repository.ts
+++ b/src/features/simulations/simulations.repository.ts
@@ -1,60 +1,21 @@
 import type { Prisma } from '@prisma/client'
 import { prisma } from '../../adapters/prisma/client'
+import {
+  defaultGroupParticipantSimulationSelection,
+  defaultOrganisationSelectionWithoutPolls,
+  defaultPollSelection,
+  defaultSimulationSelection,
+} from '../../adapters/prisma/selection'
 import type { Session } from '../../adapters/prisma/transaction'
 import { transaction } from '../../adapters/prisma/transaction'
-import {
-  defaultPollSelection,
-  organisationSelectionWithoutPolls,
-} from '../organisations/organisations.repository'
 import type { OrganisationPollParams } from '../organisations/organisations.validator'
 import { transferOwnershipToUser } from '../users/users.repository'
 import type { UserParams } from '../users/users.validator'
 import type {
+  SimulationCreateDto,
   SimulationParticipantCreateDto,
   UserSimulationParams,
 } from './simulations.validator'
-import { type SimulationCreateDto } from './simulations.validator'
-
-const defaultGroupParticipantSimulationSelection = {
-  id: true,
-  date: true,
-  situation: true,
-  foldedSteps: true,
-  progression: true,
-  actionChoices: true,
-  savedViaEmail: true,
-  computedResults: true,
-  additionalQuestionsAnswers: {
-    select: {
-      key: true,
-      answer: true,
-      type: true,
-    },
-  },
-  polls: {
-    select: {
-      pollId: true,
-      poll: {
-        select: {
-          slug: true,
-        },
-      },
-    },
-  },
-  createdAt: true,
-  updatedAt: true,
-}
-
-const defaultSimulationSelection = {
-  ...defaultGroupParticipantSimulationSelection,
-  user: {
-    select: {
-      id: true,
-      name: true,
-      email: true,
-    },
-  },
-}
 
 export const createUserSimulation = (
   simulation: SimulationCreateDto,
@@ -257,7 +218,7 @@ export const createPollUserSimulation = (
           select: {
             ...defaultPollSelection,
             organisation: {
-              select: organisationSelectionWithoutPolls,
+              select: defaultOrganisationSelectionWithoutPolls,
             },
           },
         },

--- a/src/features/simulations/simulations.validator.ts
+++ b/src/features/simulations/simulations.validator.ts
@@ -2,8 +2,8 @@ import z from 'zod'
 import { ListIds } from '../../adapters/brevo/constant'
 import { EMAIL_REGEX } from '../../core/typeguards/isValidEmail'
 import {
-  OrganisationPollParams,
   PollDefaultAdditionalQuestionTypeEnum,
+  PublicPollParams,
 } from '../organisations/organisations.validator'
 import { UserParams } from '../users/users.validator'
 
@@ -148,7 +148,6 @@ export type SituationSchema = z.infer<typeof SituationSchema>
 
 const SimulationCreateUser = z
   .object({
-    id: z.string().uuid(),
     email: z
       .string()
       .regex(EMAIL_REGEX)
@@ -181,9 +180,11 @@ export type SimulationParticipantCreateInputDto = z.input<
 >
 
 export const SimulationCreateDto = SimulationParticipantCreateDto.merge(
-  z.object({
-    user: SimulationCreateUser,
-  })
+  z
+    .object({
+      user: SimulationCreateUser.optional(),
+    })
+    .strict()
 )
 
 export type SimulationCreateDto = z.infer<typeof SimulationCreateDto>
@@ -210,7 +211,7 @@ export type SimulationCreateNewsletterList = z.infer<
 
 export const SimulationCreateValidator = {
   body: SimulationCreateDto,
-  params: z.object({}).strict().optional(),
+  params: UserParams,
   query: z
     .object({
       newsletters: SimulationCreateNewsletterList,
@@ -233,6 +234,6 @@ export const SimulationFetchValidator = {
 
 export const OrganisationPollSimulationCreateValidator = {
   body: SimulationCreateDto,
-  params: OrganisationPollParams,
+  params: PublicPollParams,
   query: z.object({}).strict().optional(),
 }

--- a/src/features/simulations/simulations.validator.ts
+++ b/src/features/simulations/simulations.validator.ts
@@ -41,7 +41,7 @@ const MetricComputedResultSchema = z
   })
   .strict()
 
-const ComputedResultSchema = z
+export const ComputedResultSchema = z
   .object({
     carbone: MetricComputedResultSchema,
     eau: MetricComputedResultSchema,

--- a/src/helpers/groups/handleUpdateGroup.ts
+++ b/src/helpers/groups/handleUpdateGroup.ts
@@ -97,7 +97,6 @@ export async function handleUpdateGroup({
         name: userDocument.name || '🦊',
         userId: userDocument.userId,
         simulation: mapSimulation(simulationSaved, {
-          id: userDocument.userId,
           email: userDocument.email,
           name: userDocument.name,
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,10 +967,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@incubateur-ademe/nosgestesclimat@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@incubateur-ademe/nosgestesclimat/-/nosgestesclimat-3.1.0.tgz#9b1e7763c9d99eba487710445bf1c8f0954268d0"
-  integrity sha512-OtvKm3xD/dtr03YHGsveZAcZJfIxlHu92GeUJTkyVs5OwhPUeSJIZZj/v6qKC6u8Smz33OwlILSZYQTTZrochw==
+"@incubateur-ademe/nosgestesclimat@^3.3.4":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@incubateur-ademe/nosgestesclimat/-/nosgestesclimat-3.3.4.tgz#16b93cb534407ef510d48120791fd0a2cc2d9ae5"
+  integrity sha512-VdQuG+TP9D0cZVipPHgW/J7boa36rFad62fzgSdMBz5895O9kWlNtmlEGHcQOv2joIDxUZxWWDSlJp73/m+JfQ==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"


### PR DESCRIPTION
Public polls spec

```
  Given a NGC user
    And logged out
      When fetching a public organisation poll
        And invalid userId
          ✓ Then it returns a 400 error (26 ms)
        And poll does not exist
          ✓ Then it returns a 404 error (17 ms)
        And poll does exist
          And he did not participate to the poll
            ✓ Then it returns a 404 error (691 ms)
          And he did participate to the poll
            ✓ Then it returns a 200 response with the poll data (1418 ms)
            And using poll slug
              ✓ Then it returns a 200 response with the poll data (1468 ms)
            And asking simulations and funFacts on poll page
              ✓ Then it returns a 200 response with the poll detailed data (1436 ms)
        And database failure
          ✓ Then it returns a 500 error (7 ms)
          ✓ Then it logs the exception (4 ms)
    And invalid cookie on his organisation space
      When fetching his organisation public poll
        And poll does exist
          ✓ Then it returns a 200 response with the public poll data (632 ms)
    And logged in on his organisation space
      When fetching his organisation public poll
        And poll does not exist
          ✓ Then it returns a 404 error (16 ms)
        And poll does exist
          ✓ Then it returns a 200 response with the private poll data (635 ms)
          And using poll slug
            ✓ Then it returns a 200 response with the private poll data (641 ms)
          And asking simulations and funFacts on poll page
            ✓ Then it returns a 200 response with the private poll detailed data (644 ms)
          And participants do their simulation
            And asking simulations and funFacts on poll page
              ✓ Then it returns a 200 response with the private poll detailed data (3278 ms)
            And trying to access user information
              ✓ Then it returns a 403 error (3418 ms)
        And database failure
          ✓ Then it returns a 500 error (16 ms)
          ✓ Then it logs the exception (14 ms)
```

Cette PR expose la donnée publique des polls aux utilisateurs organisation et campagne