### PR TITLE
:necktie: change send simulation email logic

### DIFF
--- a/src/features/groups/groups.service.ts
+++ b/src/features/groups/groups.service.ts
@@ -117,6 +117,7 @@ export const createGroup = async ({
       origin,
       simulation,
       administrator,
+      sendEmail: true,
       user: administrator,
     })
 
@@ -182,6 +183,7 @@ export const createParticipant = async ({
     })
 
     const simulationUpsertedEvent = new SimulationUpsertedEvent({
+      sendEmail: true,
       administrator,
       simulation,
       origin,

--- a/src/features/simulations/__tests__/create-simulation.spec.ts
+++ b/src/features/simulations/__tests__/create-simulation.spec.ts
@@ -180,8 +180,6 @@ describe('Given a NGC user', () => {
         }
 
         nock(process.env.BREVO_URL!)
-          .post('/v3/smtp/email')
-          .reply(200)
           .post('/v3/contacts')
           .reply(200)
           .post('/v3/contacts/lists/35/contacts/remove')
@@ -274,8 +272,6 @@ describe('Given a NGC user', () => {
                 'api-key': process.env.BREVO_API_KEY!,
               },
             })
-              .post('/v3/smtp/email')
-              .reply(200)
               .post('/v3/contacts', {
                 email,
                 attributes: {
@@ -397,6 +393,7 @@ describe('Given a NGC user', () => {
             await agent
               .post(url.replace(':userId', faker.string.uuid()))
               .send(payload)
+              .query({ sendEmail: true })
               .expect(StatusCodes.CREATED)
 
             expect(scope.isDone()).toBeTruthy()
@@ -454,6 +451,7 @@ describe('Given a NGC user', () => {
               await agent
                 .post(url.replace(':userId', faker.string.uuid()))
                 .send(payload)
+                .query({ sendEmail: true })
                 .set('origin', 'https://preprod.nosgestesclimat.fr')
                 .expect(StatusCodes.CREATED)
 
@@ -484,8 +482,6 @@ describe('Given a NGC user', () => {
                   'api-key': process.env.BREVO_API_KEY!,
                 },
               })
-                .post('/v3/smtp/email')
-                .reply(200)
                 .post('/v3/contacts', {
                   email,
                   listIds: [22, 32, 36],
@@ -570,8 +566,6 @@ describe('Given a NGC user', () => {
                 'api-key': process.env.BREVO_API_KEY!,
               },
             })
-              .post('/v3/smtp/email')
-              .reply(200)
               .post('/v3/contacts', {
                 email,
                 listIds: [35],
@@ -627,6 +621,7 @@ describe('Given a NGC user', () => {
             await agent
               .post(url.replace(':userId', faker.string.uuid()))
               .send(payload)
+              .query({ sendEmail: true })
               .expect(StatusCodes.CREATED)
 
             expect(scope.isDone()).toBeTruthy()

--- a/src/features/simulations/__tests__/fixtures/simulations.fixtures.ts
+++ b/src/features/simulations/__tests__/fixtures/simulations.fixtures.ts
@@ -213,10 +213,6 @@ export const createSimulation = async ({
       .reply(400, { code: 'invalid_parameter' })
       .post('/v3/contacts/lists/36/contacts/remove')
       .reply(400, { code: 'invalid_parameter' })
-
-    if (payload.progression === 1) {
-      scope.post('/v3/smtp/email').reply(200)
-    }
   }
 
   const response = await agent

--- a/src/features/simulations/events/SimulationUpserted.event.ts
+++ b/src/features/simulations/events/SimulationUpserted.event.ts
@@ -14,6 +14,7 @@ export class SimulationUpsertedEvent extends EventBusEvent<
       administrator?: undefined
       organisation?: undefined
       newsletters: SimulationCreateNewsletterList
+      sendEmail: boolean
     }
   | {
       origin: string
@@ -26,6 +27,7 @@ export class SimulationUpsertedEvent extends EventBusEvent<
       administrator: Pick<User, 'id'>
       organisation?: undefined
       newsletters?: undefined
+      sendEmail: boolean
     }
   | {
       origin: string
@@ -38,5 +40,6 @@ export class SimulationUpsertedEvent extends EventBusEvent<
       administrator?: undefined
       organisation: Pick<Organisation, 'name' | 'slug'>
       newsletters?: undefined
+      sendEmail: boolean
     }
 > {}

--- a/src/features/simulations/handlers/send-simulation-upserted.ts
+++ b/src/features/simulations/handlers/send-simulation-upserted.ts
@@ -9,9 +9,9 @@ import type { SimulationUpsertedEvent } from '../events/SimulationUpserted.event
 
 export const sendSimulationUpserted: Handler<SimulationUpsertedEvent> = ({
   attributes,
-  attributes: { origin, user, organisation, simulation },
+  attributes: { origin, user, organisation, simulation, sendEmail },
 }) => {
-  if (!user.email) {
+  if (!user.email || !sendEmail) {
     return
   }
 

--- a/src/features/simulations/simulations.controller.ts
+++ b/src/features/simulations/simulations.controller.ts
@@ -41,6 +41,7 @@ router
         newsletters: SimulationCreateNewsletterList.parse(
           req.query?.newsletters || []
         ),
+        sendEmail: !!req.query?.sendEmail,
         params: req.params,
         origin: req.get('origin') || config.origin,
       })

--- a/src/features/simulations/simulations.service.ts
+++ b/src/features/simulations/simulations.service.ts
@@ -53,11 +53,13 @@ const simulationToDto = (
 export const createSimulation = async ({
   simulationDto,
   newsletters,
+  sendEmail,
   params,
   origin,
 }: {
   simulationDto: SimulationCreateDto
   newsletters: SimulationCreateNewsletterList
+  sendEmail: boolean
   params: UserParams
   origin: string
 }) => {
@@ -67,6 +69,7 @@ export const createSimulation = async ({
   const simulationUpsertedEvent = new SimulationUpsertedEvent({
     newsletters,
     simulation,
+    sendEmail,
     origin,
     user,
   })
@@ -120,6 +123,7 @@ export const createPollSimulation = async ({
     })
 
     const simulationUpsertedEvent = new SimulationUpsertedEvent({
+      sendEmail: true,
       organisation,
       simulation,
       origin,

--- a/src/features/simulations/simulations.validator.ts
+++ b/src/features/simulations/simulations.validator.ts
@@ -215,6 +215,7 @@ export const SimulationCreateValidator = {
   query: z
     .object({
       newsletters: SimulationCreateNewsletterList,
+      sendEmail: z.coerce.boolean().optional(),
     })
     .strict()
     .optional(),


### PR DESCRIPTION
Require a `sendEmail=true` queryParam when creating/updating a simulation