### PR TITLE
:necktie: Change update user & contact logic (NGC-1442)

### DIFF
--- a/src/adapters/brevo/client.ts
+++ b/src/adapters/brevo/client.ts
@@ -384,7 +384,7 @@ export const addOrUpdateContactAndNewsLetterSubscriptions = async ({
     name?: string | null
   }
   email: string
-  listIds: ListIds[]
+  listIds?: ListIds[]
 }) => {
   const attributes = {
     [Attributes.USER_ID]: user.id,
@@ -397,24 +397,21 @@ export const addOrUpdateContactAndNewsLetterSubscriptions = async ({
     listIds,
   })
 
-  const wantedListIds = new Set(listIds)
-  const contact = await fetchContact(email)
+  if (listIds) {
+    const wantedListIds = new Set(listIds)
+    const contact = await fetchContact(email)
 
-  await contact.listIds.reduce(async (promise, listId) => {
-    await promise
+    await contact.listIds.reduce(async (promise, listId) => {
+      await promise
 
-    if (!wantedListIds.has(listId)) {
-      await unsubscribeContactFromList({
-        email,
-        listId,
-      })
-    }
-  }, Promise.resolve())
-
-  // Spare fetch request again
-  contact.listIds = listIds
-
-  return contact
+      if (!wantedListIds.has(listId)) {
+        await unsubscribeContactFromList({
+          email,
+          listId,
+        })
+      }
+    }, Promise.resolve())
+  }
 }
 
 export const addOrUpdateContactAfterOrganisationChange = async ({

--- a/src/features/newsletter/__tests__/fetch-newsletter.spec.ts
+++ b/src/features/newsletter/__tests__/fetch-newsletter.spec.ts
@@ -17,7 +17,7 @@ describe('Given a NGC user', () => {
     const newsletterTotalSubscribers = faker.number.int()
 
     describe('And invalid newsletterId', () => {
-      it(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
         await agent
           .get(url.replace(':newsletterId', 'invalid-newsletterId'))
           .expect(StatusCodes.BAD_REQUEST)
@@ -28,7 +28,7 @@ describe('Given a NGC user', () => {
       })
     })
 
-    it(`Then it returns a ${StatusCodes.OK} response with the mapped brevo response`, async () => {
+    test(`Then it returns a ${StatusCodes.OK} response with the mapped brevo response`, async () => {
       const scope = nock(process.env.BREVO_URL!, {
         reqheaders: {
           'api-key': process.env.BREVO_API_KEY!,
@@ -62,7 +62,7 @@ describe('Given a NGC user', () => {
     })
 
     describe('And newsletter does not exists', () => {
-      it(`Then it returns a ${StatusCodes.NOT_FOUND} response with the mapped brevo response`, async () => {
+      test(`Then it returns a ${StatusCodes.NOT_FOUND} response with the mapped brevo response`, async () => {
         const scope = nock(process.env.BREVO_URL!, {
           reqheaders: {
             'api-key': process.env.BREVO_API_KEY!,
@@ -87,7 +87,7 @@ describe('Given a NGC user', () => {
     })
 
     describe('And network error', () => {
-      it(`Then it returns a ${StatusCodes.NOT_FOUND} response`, async () => {
+      test(`Then it returns a ${StatusCodes.NOT_FOUND} response`, async () => {
         const scope = nock(process.env.BREVO_URL!, {
           reqheaders: {
             'api-key': process.env.BREVO_API_KEY!,
@@ -109,7 +109,7 @@ describe('Given a NGC user', () => {
     })
 
     describe('And brevo is down', () => {
-      it(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response after retries`, async () => {
+      test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response after retries`, async () => {
         const scope = nock(process.env.BREVO_URL!, {
           reqheaders: {
             'api-key': process.env.BREVO_API_KEY!,
@@ -134,7 +134,7 @@ describe('Given a NGC user', () => {
     })
 
     describe('And brevo interface changes', () => {
-      it(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response and logs the exception`, async () => {
+      test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response and logs the exception`, async () => {
         const scope = nock(process.env.BREVO_URL!, {
           reqheaders: {
             'api-key': process.env.BREVO_API_KEY!,

--- a/src/features/users/__tests__/fetch-user-brevo-contact.spec.ts
+++ b/src/features/users/__tests__/fetch-user-brevo-contact.spec.ts
@@ -12,7 +12,7 @@ import { createSimulation } from '../../simulations/__tests__/fixtures/simulatio
 
 describe('Given a NGC user', () => {
   const agent = supertest(app)
-  const url = '/users/v1/:userId/brevo-contact'
+  const url = '/users/v1/:userId/contact'
 
   afterEach(() => prisma.user.deleteMany())
 
@@ -72,7 +72,7 @@ describe('Given a NGC user', () => {
           listIds = [faker.number.int(), faker.number.int()]
         })
 
-        test(`Then it returns a ${StatusCodes.OK} response with the mapped brevo contact`, async () => {
+        test(`Then it returns a ${StatusCodes.OK} response with the mapped user contact`, async () => {
           const scope = nock(process.env.BREVO_URL!, {
             reqheaders: {
               'api-key': process.env.BREVO_API_KEY!,
@@ -105,8 +105,8 @@ describe('Given a NGC user', () => {
           expect(scope.isDone()).toBeTruthy()
         })
 
-        describe('And brevo contact does not exist', () => {
-          it(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
+        describe('And user contact does not exist', () => {
+          test(`Then it returns a ${StatusCodes.NOT_FOUND} error`, async () => {
             const scope = nock(process.env.BREVO_URL!, {
               reqheaders: {
                 'api-key': process.env.BREVO_API_KEY!,
@@ -127,7 +127,7 @@ describe('Given a NGC user', () => {
         })
 
         describe('And network error', () => {
-          it(`Then it returns a ${StatusCodes.NOT_FOUND} response`, async () => {
+          test(`Then it returns a ${StatusCodes.NOT_FOUND} response`, async () => {
             const scope = nock(process.env.BREVO_URL!, {
               reqheaders: {
                 'api-key': process.env.BREVO_API_KEY!,
@@ -149,7 +149,7 @@ describe('Given a NGC user', () => {
         })
 
         describe('And brevo is down', () => {
-          it(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response after retries and logs the exception`, async () => {
+          test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response after retries and logs the exception`, async () => {
             const scope = nock(process.env.BREVO_URL!, {
               reqheaders: {
                 'api-key': process.env.BREVO_API_KEY!,
@@ -171,14 +171,14 @@ describe('Given a NGC user', () => {
             expect(body).toEqual({})
             expect(scope.isDone()).toBeTruthy()
             expect(logger.error).toHaveBeenCalledWith(
-              'User brevo contact fetch failed',
+              'User contact fetch failed',
               expect.any(AxiosError)
             )
           })
         })
 
         describe('And brevo interface changes', () => {
-          it(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response and logs the exception`, async () => {
+          test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} response and logs the exception`, async () => {
             const scope = nock(process.env.BREVO_URL!, {
               reqheaders: {
                 'api-key': process.env.BREVO_API_KEY!,
@@ -194,7 +194,7 @@ describe('Given a NGC user', () => {
             expect(body).toEqual({})
             expect(scope.isDone()).toBeTruthy()
             expect(logger.error).toHaveBeenCalledWith(
-              'User brevo contact fetch failed',
+              'User contact fetch failed',
               expect.any(ZodError)
             )
           })

--- a/src/features/users/events/UserUpdated.event.ts
+++ b/src/features/users/events/UserUpdated.event.ts
@@ -1,0 +1,8 @@
+import type { User } from '@prisma/client'
+import type { ListIds } from '../../../adapters/brevo/constant'
+import { EventBusEvent } from '../../../core/event-bus/event'
+
+export class UserUpdatedEvent extends EventBusEvent<{
+  user: Pick<User, 'id' | 'name' | 'email'>
+  listIds?: ListIds[]
+}> {}

--- a/src/features/users/handlers/add-or-update-brevo-contact.ts
+++ b/src/features/users/handlers/add-or-update-brevo-contact.ts
@@ -1,0 +1,20 @@
+import { addOrUpdateContactAndNewsLetterSubscriptions } from '../../../adapters/brevo/client'
+import type { Handler } from '../../../core/event-bus/handler'
+import type { UserUpdatedEvent } from '../events/UserUpdated.event'
+
+export const addOrUpdateBrevoContact: Handler<UserUpdatedEvent> = async ({
+  attributes: {
+    user: { email, ...user },
+    listIds,
+  },
+}) => {
+  if (!email) {
+    return
+  }
+
+  return addOrUpdateContactAndNewsLetterSubscriptions({
+    listIds,
+    email,
+    user,
+  })
+}

--- a/src/features/users/users.controller.ts
+++ b/src/features/users/users.controller.ts
@@ -6,22 +6,22 @@ import { EventBus } from '../../core/event-bus/event-bus'
 import logger from '../../logger'
 import { UserUpdatedEvent } from './events/UserUpdated.event'
 import { addOrUpdateBrevoContact } from './handlers/add-or-update-brevo-contact'
-import { fetchUserBrevoContact, updateUserAndContact } from './users.service'
+import { fetchUserContact, updateUserAndContact } from './users.service'
 import {
-  FetchUserBrevoContactValidator,
+  FetchUserContactValidator,
   UpdateUserValidator,
 } from './users.validator'
 
 const router = express.Router()
 
 /**
- * Returns brevo contact for given user id
+ * Returns user contact for given user id
  */
 router
-  .route('/v1/:userId/brevo-contact')
-  .get(validateRequest(FetchUserBrevoContactValidator), async (req, res) => {
+  .route('/v1/:userId/contact')
+  .get(validateRequest(FetchUserContactValidator), async (req, res) => {
     try {
-      const contact = await fetchUserBrevoContact(req.params)
+      const contact = await fetchUserContact(req.params)
 
       return res.status(StatusCodes.OK).json(contact)
     } catch (err) {
@@ -29,7 +29,7 @@ router
         return res.status(StatusCodes.NOT_FOUND).send(err.message).end()
       }
 
-      logger.error('User brevo contact fetch failed', err)
+      logger.error('User contact fetch failed', err)
 
       return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
     }

--- a/src/features/users/users.repository.ts
+++ b/src/features/users/users.repository.ts
@@ -183,7 +183,7 @@ export const fetchUser = (
 
 export const updateUser = (
   { userId }: UserParams,
-  { email }: Pick<User, 'email'>,
+  { email, name }: Partial<Pick<User, 'email' | 'name'>>,
   { session }: { session?: Session } = {}
 ) => {
   return transaction(
@@ -194,6 +194,7 @@ export const updateUser = (
         },
         data: {
           email,
+          name,
         },
         select: defaultUserSelection,
       }),

--- a/src/features/users/users.service.ts
+++ b/src/features/users/users.service.ts
@@ -22,7 +22,7 @@ export const syncUserData = (user: NonNullable<Request['user']>) => {
   return transferOwnershipToUser(user)
 }
 
-export const fetchUserBrevoContact = async (params: UserParams) => {
+export const fetchUserContact = async (params: UserParams) => {
   try {
     const user = await fetchUser(params)
 

--- a/src/features/users/users.validator.ts
+++ b/src/features/users/users.validator.ts
@@ -16,22 +16,26 @@ export const FetchUserBrevoContactValidator = {
   query: z.object({}).strict().optional(),
 }
 
-const UserBrevoContactUpdateDto = z
+const UserUpdateDto = z
   .object({
     email: z
       .string()
       .regex(EMAIL_REGEX)
       .transform((email) => email.toLocaleLowerCase()),
-    listIds: z.array(z.nativeEnum(ListIds)),
+    name: z.string(),
+    contact: z
+      .object({
+        listIds: z.array(z.nativeEnum(ListIds)),
+      })
+      .strict(),
   })
   .strict()
+  .partial()
 
-export type UserBrevoContactUpdateDto = z.infer<
-  typeof UserBrevoContactUpdateDto
->
+export type UserUpdateDto = z.infer<typeof UserUpdateDto>
 
-export const UpdateUserBrevoContactValidator = {
-  body: UserBrevoContactUpdateDto,
+export const UpdateUserValidator = {
+  body: UserUpdateDto,
   params: UserParams,
   query: z.object({}).strict().optional(),
 }

--- a/src/features/users/users.validator.ts
+++ b/src/features/users/users.validator.ts
@@ -10,7 +10,7 @@ export const UserParams = z
 
 export type UserParams = z.infer<typeof UserParams>
 
-export const FetchUserBrevoContactValidator = {
+export const FetchUserContactValidator = {
   body: z.object({}).strict().optional(),
   params: UserParams,
   query: z.object({}).strict().optional(),


### PR DESCRIPTION
As the update-settings route updated the user's name, the route update user contact becomes update user.

Clean test and remove brevo from API also

```
 PASS  src/features/users/__tests__/fetch-user-brevo-contact.spec.ts (9.979 s)
  Given a NGC user
    When fetching the newsletter stats
      And invalid userId
        ✓ Then it returns a 400 error (53 ms)
      And user does not exist
        ✓ Then it returns a 404 error (36 ms)
      And user does exist
        And has no email
          ✓ Then it returns a 404 error (747 ms)
        And has an email
          ✓ Then it returns a 200 response with the mapped user contact (777 ms)
          And user contact does not exist
            ✓ Then it returns a 404 error (978 ms)
          And network error
            ✓ Then it returns a 404 response (1555 ms)
          And brevo is down
            ✓ Then it returns a 500 response after retries and logs the exception (1551 ms)
          And brevo interface changes
            ✓ Then it returns a 500 response and logs the exception (722 ms)

 PASS  src/features/users/__tests__/update-user.spec.ts (12.264 s)
  Given a NGC user
    When updating his/her user
      And invalid userId
        ✓ Then it returns a 400 error (59 ms)
      And invalid email
        ✓ Then it returns a 400 error (22 ms)
      And invalid newsletters
        ✓ Then it returns a 400 error (21 ms)
      And user does not exist
        ✓ Then it returns a 404 error (30 ms)
      And user does exist
        And has no email
          ✓ Then it sets the name and returns a 200 response with the user (851 ms)
          ✓ Then it sets the email and returns a 200 response with the user (695 ms)
          And database failure
            ✓ Then it returns a 500 error (908 ms)
            ✓ Then it logs the exception (892 ms)
        And has an email
          ✓ Then it returns a 200 response with the user (810 ms)
          And already has newsLetters
            ✓ Then it unsubscribes unwanted newsletters and it returns a 200 response with the user (763 ms)
          And network error
            ✓ Then it returns a 404 response and logs the exception (1590 ms)
          And brevo is down
            ✓ Then it returns a 500 response after retries and logs the exception (1365 ms)
          And brevo interface changes
            ✓ Then it returns a 500 response and logs the exception (682 ms)
``` 