### PR TITLE
:sparkles: update user newsletters (NGC-1727)

### DIFF
--- a/src/adapters/brevo/constant.ts
+++ b/src/adapters/brevo/constant.ts
@@ -10,6 +10,7 @@ export enum TemplateIds {
   ORGANISATION_JOINED = 71,
   SIMULATION_IN_PROGRESS = 102,
   API_VERIFICATION_CODE = 116,
+  NEWSLETTER_CONFIRMATION = 118,
 }
 
 export enum Attributes {

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,14 @@ export const config = {
     process.env.NODE_ENV,
     'development' as 'development' | 'production' | 'test'
   ),
+  get serverUrl() {
+    return ensureEnvVar(
+      process.env.SERVER_URL,
+      config.env === 'development'
+        ? 'http://localhost:3001'
+        : 'https://server.nosgestesclimat.fr'
+    )
+  },
   origin: ensureEnvVar(process.env.ORIGIN, 'https://nosgestesclimat.fr'),
   get app() {
     return {

--- a/src/core/typeguards/isAuthenticated.ts
+++ b/src/core/typeguards/isAuthenticated.ts
@@ -1,0 +1,6 @@
+import type { Request } from 'express'
+import type { UserParams } from '../../features/users/users.validator'
+
+export const isAuthenticated = (
+  user: UserParams | NonNullable<Request['user']>
+): user is NonNullable<Request['user']> => 'email' in user && !!user.email

--- a/src/features/authentication/verification-codes.service.ts
+++ b/src/features/authentication/verification-codes.service.ts
@@ -6,14 +6,8 @@ import { VerificationCodeCreatedEvent } from './events/VerificationCodeCreated.e
 import { createUserVerificationCode } from './verification-codes.repository'
 import type { VerificationCodeCreateDto } from './verification-codes.validator'
 
-export const createVerificationCode = async (
-  {
-    verificationCodeDto,
-    origin,
-  }: {
-    verificationCodeDto: Pick<VerificationCodeCreateDto, 'email'>
-    origin: string
-  },
+export const generateVerificationCode = async (
+  verificationCodeDto: Pick<VerificationCodeCreateDto, 'email'>,
   { session }: { session?: Session } = {}
 ) => {
   const { code, expirationDate } = generateVerificationCodeAndExpiration()
@@ -28,6 +22,24 @@ export const createVerificationCode = async (
         },
         { session }
       ),
+    session
+  )
+
+  return { code, verificationCode }
+}
+
+export const createVerificationCode = async (
+  {
+    verificationCodeDto,
+    origin,
+  }: {
+    verificationCodeDto: Pick<VerificationCodeCreateDto, 'email'>
+    origin: string
+  },
+  session: { session?: Session } = {}
+) => {
+  const { verificationCode, code } = await generateVerificationCode(
+    verificationCodeDto,
     session
   )
 

--- a/src/features/authentication/verification-codes.service.ts
+++ b/src/features/authentication/verification-codes.service.ts
@@ -1,13 +1,17 @@
 import type { Session } from '../../adapters/prisma/transaction'
 import { transaction } from '../../adapters/prisma/transaction'
 import { EventBus } from '../../core/event-bus/event-bus'
+import type { WithOptionalProperty } from '../../types/types'
 import { generateVerificationCodeAndExpiration } from './authentication.service'
 import { VerificationCodeCreatedEvent } from './events/VerificationCodeCreated.event'
 import { createUserVerificationCode } from './verification-codes.repository'
 import type { VerificationCodeCreateDto } from './verification-codes.validator'
 
 export const generateVerificationCode = async (
-  verificationCodeDto: Pick<VerificationCodeCreateDto, 'email'>,
+  verificationCodeDto: WithOptionalProperty<
+    VerificationCodeCreateDto,
+    'userId'
+  >,
   { session }: { session?: Session } = {}
 ) => {
   const { code, expirationDate } = generateVerificationCodeAndExpiration()

--- a/src/features/users/__tests__/confirm-newsletter-subscriptions.spec.ts
+++ b/src/features/users/__tests__/confirm-newsletter-subscriptions.spec.ts
@@ -1,0 +1,421 @@
+import { faker } from '@faker-js/faker'
+import dayjs from 'dayjs'
+import { StatusCodes } from 'http-status-codes'
+import supertest from 'supertest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { formatBrevoDate } from '../../../adapters/brevo/__tests__/fixtures/formatBrevoDate'
+import {
+  brevoGetContact,
+  brevoRemoveFromList,
+  brevoUpdateContact,
+} from '../../../adapters/brevo/__tests__/fixtures/server.fixture'
+import { ListIds } from '../../../adapters/brevo/constant'
+import { prisma } from '../../../adapters/prisma/client'
+import * as prismaTransactionAdapter from '../../../adapters/prisma/transaction'
+import app from '../../../app'
+import { mswServer } from '../../../core/__tests__/fixtures/server.fixture'
+import logger from '../../../logger'
+import { subscribeToNewsLetter } from './fixtures/users.fixture'
+
+vi.mock('../../../adapters/prisma/transaction', async () => ({
+  ...(await vi.importActual('../../../adapters/prisma/transaction')),
+}))
+
+describe('Given a NGC user', () => {
+  const agent = supertest(app)
+  const url = '/users/v1/:userId/newsletter-confirmation'
+
+  afterEach(() =>
+    Promise.all([
+      prisma.user.deleteMany(),
+      prisma.verificationCode.deleteMany(),
+    ])
+  )
+
+  describe('When clicking the confirmation email link', () => {
+    describe('And invalid userId', () => {
+      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+        await agent
+          .get(url.replace(':userId', faker.string.alpha(34)))
+          .query({
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+            email: faker.internet.email(),
+          })
+          .expect(StatusCodes.BAD_REQUEST)
+      })
+    })
+
+    describe('And invalid email', () => {
+      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+        await agent
+          .get(url.replace(':userId', faker.string.uuid()))
+          .query({
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+            email: 'Je ne donne jamais mon email',
+          })
+          .expect(StatusCodes.BAD_REQUEST)
+      })
+    })
+
+    describe('And invalid newsLetters', () => {
+      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
+        await agent
+          .get(url.replace(':userId', faker.string.uuid()))
+          .query({
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+            email: faker.internet.email,
+            listIds: [-1],
+          })
+          .expect(StatusCodes.BAD_REQUEST)
+      })
+    })
+
+    describe('And database failure', () => {
+      const databaseError = new Error('Something went wrong')
+
+      beforeEach(() => {
+        vi.spyOn(prismaTransactionAdapter, 'transaction').mockRejectedValueOnce(
+          databaseError
+        )
+      })
+
+      afterEach(() => {
+        vi.spyOn(prismaTransactionAdapter, 'transaction').mockRestore()
+      })
+
+      test('Then it redirects to an error page', async () => {
+        const response = await agent
+          .get(url.replace(':userId', faker.string.uuid()))
+          .query({
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+            email: faker.internet.email().toLocaleLowerCase(),
+            listIds: [ListIds.MAIN_NEWSLETTER],
+          })
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.fr/?newsletter-confirmation-success=false&newsletter-confirmation-status=500'
+        )
+      })
+
+      test('Then it logs the exception', async () => {
+        await agent
+          .get(url.replace(':userId', faker.string.uuid()))
+          .query({
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+            email: faker.internet.email().toLocaleLowerCase(),
+            listIds: [ListIds.MAIN_NEWSLETTER],
+          })
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(logger.error).toHaveBeenCalledWith(
+          'Newsletter confirmation failed',
+          databaseError
+        )
+      })
+    })
+  })
+
+  describe('With an ongoing newsletter subscription request', () => {
+    let listIds: string[]
+    let userId: string
+    let email: string
+    let code: string
+
+    describe('And main newsletter', () => {
+      beforeEach(async () => {
+        ;({
+          id: userId,
+          listIds,
+          email,
+          code,
+        } = await subscribeToNewsLetter({
+          agent,
+        }))
+      })
+
+      describe('When clicking the confirmation email link', () => {
+        test('Then it redirects to a success page', async () => {
+          mswServer.use(
+            brevoGetContact(email, {
+              customResponses: [
+                {
+                  body: {
+                    code: 'document_not_found',
+                    message: 'List ID does not exist',
+                  },
+                  status: StatusCodes.NOT_FOUND,
+                },
+              ],
+            }),
+            brevoUpdateContact({
+              expectBody: {
+                email,
+                attributes: {
+                  USER_ID: userId,
+                  PRENOM: null,
+                },
+                updateEnabled: true,
+                listIds: [ListIds.MAIN_NEWSLETTER],
+              },
+            })
+          )
+
+          const response = await agent
+            .get(url.replace(':userId', userId))
+            .query({
+              code,
+              email,
+              listIds,
+            })
+            .expect(StatusCodes.MOVED_TEMPORARILY)
+
+          expect(response.get('location')).toBe(
+            'https://nosgestesclimat.fr/?newsletter-confirmation-success=true'
+          )
+        })
+
+        describe('And custom user origin (preprod)', () => {
+          test('Then it redirects to a success page', async () => {
+            mswServer.use(
+              brevoGetContact(email, {
+                customResponses: [
+                  {
+                    body: {
+                      code: 'document_not_found',
+                      message: 'List ID does not exist',
+                    },
+                    status: StatusCodes.NOT_FOUND,
+                  },
+                ],
+              }),
+              brevoUpdateContact({
+                expectBody: {
+                  email,
+                  attributes: {
+                    USER_ID: userId,
+                    PRENOM: null,
+                  },
+                  updateEnabled: true,
+                  listIds: [ListIds.MAIN_NEWSLETTER],
+                },
+              })
+            )
+
+            const response = await agent
+              .get(url.replace(':userId', userId))
+              .set('origin', 'https://preprod.nosgestesclimat.fr')
+              .query({
+                code,
+                email,
+                listIds,
+              })
+              .expect(StatusCodes.MOVED_TEMPORARILY)
+
+            expect(response.get('location')).toBe(
+              'https://preprod.nosgestesclimat.fr/?newsletter-confirmation-success=true'
+            )
+          })
+        })
+      })
+    })
+
+    describe('And several newsletters', () => {
+      beforeEach(async () => {
+        ;({
+          id: userId,
+          listIds,
+          email,
+          code,
+        } = await subscribeToNewsLetter({
+          agent,
+          user: {
+            contact: {
+              listIds: [
+                ListIds.MAIN_NEWSLETTER,
+                ListIds.LOGEMENT_NEWSLETTER,
+                ListIds.TRANSPORT_NEWSLETTER,
+              ],
+            },
+          },
+        }))
+      })
+
+      describe('When clicking the confirmation email link', () => {
+        test('Then it redirects to a success page', async () => {
+          mswServer.use(
+            brevoGetContact(email, {
+              customResponses: [
+                {
+                  body: {
+                    code: 'document_not_found',
+                    message: 'List ID does not exist',
+                  },
+                  status: StatusCodes.NOT_FOUND,
+                },
+              ],
+            }),
+            brevoUpdateContact({
+              expectBody: {
+                email,
+                attributes: {
+                  USER_ID: userId,
+                  PRENOM: null,
+                },
+                updateEnabled: true,
+                listIds: [
+                  ListIds.MAIN_NEWSLETTER,
+                  ListIds.LOGEMENT_NEWSLETTER,
+                  ListIds.TRANSPORT_NEWSLETTER,
+                ],
+              },
+            })
+          )
+
+          const response = await agent
+            .get(url.replace(':userId', userId))
+            .query({
+              code,
+              email,
+              'listIds[]': listIds,
+            })
+            .expect(StatusCodes.MOVED_TEMPORARILY)
+
+          expect(response.get('location')).toBe(
+            'https://nosgestesclimat.fr/?newsletter-confirmation-success=true'
+          )
+        })
+      })
+    })
+
+    describe('And user already has a brevo contact with some subscribed news letters', () => {
+      beforeEach(async () => {
+        ;({
+          id: userId,
+          listIds,
+          email,
+          code,
+        } = await subscribeToNewsLetter({
+          agent,
+          user: {
+            contact: {
+              listIds: [ListIds.LOGEMENT_NEWSLETTER],
+            },
+          },
+        }))
+      })
+
+      describe('When clicking the confirmation email link', () => {
+        test('Then it redirects to a success page', async () => {
+          mswServer.use(
+            brevoGetContact(email, {
+              customResponses: [
+                {
+                  body: {
+                    email,
+                    id: faker.number.int(),
+                    emailBlacklisted: faker.datatype.boolean(),
+                    smsBlacklisted: faker.datatype.boolean(),
+                    createdAt: formatBrevoDate(faker.date.past()),
+                    modifiedAt: formatBrevoDate(faker.date.recent()),
+                    attributes: {
+                      USER_ID: userId,
+                      PRENOM: null,
+                    },
+                    listIds: [
+                      ListIds.UNFINISHED_SIMULATION,
+                      ListIds.MAIN_NEWSLETTER,
+                    ],
+                    statistics: {},
+                  },
+                },
+              ],
+            }),
+            brevoRemoveFromList(ListIds.MAIN_NEWSLETTER, {
+              expectBody: {
+                emails: [email],
+              },
+            }),
+            brevoUpdateContact({
+              expectBody: {
+                email,
+                attributes: {
+                  USER_ID: userId,
+                  PRENOM: null,
+                },
+                updateEnabled: true,
+                listIds: expect.arrayContaining([
+                  ListIds.UNFINISHED_SIMULATION,
+                  ListIds.LOGEMENT_NEWSLETTER,
+                ]),
+              },
+            })
+          )
+
+          const response = await agent
+            .get(url.replace(':userId', userId))
+            .query({
+              code,
+              email,
+              listIds,
+            })
+            .expect(StatusCodes.MOVED_TEMPORARILY)
+
+          expect(response.get('location')).toBe(
+            'https://nosgestesclimat.fr/?newsletter-confirmation-success=true'
+          )
+        })
+      })
+    })
+  })
+
+  describe('With an expired newsletter subscription request', () => {
+    let listIds: string[]
+    let userId: string
+    let email: string
+    let code: string
+
+    beforeEach(async () => {
+      ;({
+        id: userId,
+        listIds,
+        email,
+        code,
+      } = await subscribeToNewsLetter({
+        agent,
+        expirationDate: dayjs().subtract(1, 'second').toDate(),
+      }))
+    })
+
+    describe('When clicking the confirmation email link', () => {
+      test('Then it redirects to an error page', async () => {
+        mswServer.use(
+          brevoGetContact(email, {
+            customResponses: [
+              {
+                body: {
+                  code: 'document_not_found',
+                  message: 'List ID does not exist',
+                },
+                status: StatusCodes.NOT_FOUND,
+              },
+            ],
+          })
+        )
+
+        const response = await agent
+          .get(url.replace(':userId', userId))
+          .query({
+            code,
+            email,
+            listIds,
+          })
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.fr/?newsletter-confirmation-success=false&newsletter-confirmation-status=404'
+        )
+      })
+    })
+  })
+})

--- a/src/features/users/__tests__/fixtures/users.fixture.ts
+++ b/src/features/users/__tests__/fixtures/users.fixture.ts
@@ -1,0 +1,89 @@
+import { faker } from '@faker-js/faker'
+import dayjs from 'dayjs'
+import { StatusCodes } from 'http-status-codes'
+import type supertest from 'supertest'
+import { vi } from 'vitest'
+import {
+  brevoGetContact,
+  brevoSendEmail,
+} from '../../../../adapters/brevo/__tests__/fixtures/server.fixture'
+import { ListIds } from '../../../../adapters/brevo/constant'
+import {
+  mswServer,
+  resetMswServer,
+} from '../../../../core/__tests__/fixtures/server.fixture'
+import { EventBus } from '../../../../core/event-bus/event-bus'
+import * as authenticationService from '../../../authentication/authentication.service'
+import type { UserUpdateDto } from '../../users.validator'
+
+type TestAgent = ReturnType<typeof supertest>
+
+export const UPDATE_USER_ROUTE = '/users/v1/:userId'
+
+export const subscribeToNewsLetter = async ({
+  code,
+  agent,
+  expirationDate,
+  user: { id, name, email, contact } = {},
+}: {
+  agent: TestAgent
+  user?: Partial<UserUpdateDto> & { id?: string }
+  code?: string
+  expirationDate?: Date
+}) => {
+  code = code || faker.number.int({ min: 100000, max: 999999 }).toString()
+  expirationDate = expirationDate || dayjs().add(1, 'hour').toDate()
+
+  vi.mocked(
+    authenticationService
+  ).generateVerificationCodeAndExpiration.mockReturnValueOnce({
+    code,
+    expirationDate,
+  })
+
+  email = email || faker.internet.email().toLocaleLowerCase()
+
+  const listIds = contact?.listIds.length
+    ? contact?.listIds
+    : [ListIds.MAIN_NEWSLETTER]
+
+  const payload: UserUpdateDto = {
+    contact: contact || { listIds },
+    email,
+    name,
+  }
+
+  mswServer.use(
+    brevoGetContact(email, {
+      customResponses: [
+        {
+          body: {
+            code: 'document_not_found',
+            message: 'List ID does not exist',
+          },
+          status: StatusCodes.NOT_FOUND,
+        },
+      ],
+    }),
+    brevoSendEmail()
+  )
+
+  const response = await agent
+    .put(UPDATE_USER_ROUTE.replace(':userId', id || faker.string.uuid()))
+    .send(payload)
+    .expect(StatusCodes.ACCEPTED)
+
+  await EventBus.flush()
+
+  resetMswServer()
+
+  vi.mocked(
+    authenticationService
+  ).generateVerificationCodeAndExpiration.mockRestore()
+
+  return {
+    ...response.body,
+    listIds,
+    code,
+  }
+}

--- a/src/features/users/__tests__/update-user.spec.ts
+++ b/src/features/users/__tests__/update-user.spec.ts
@@ -19,10 +19,11 @@ import logger from '../../../logger'
 import { login } from '../../authentication/__tests__/fixtures/login.fixture'
 import * as authenticationService from '../../authentication/authentication.service'
 import { createSimulation } from '../../simulations/__tests__/fixtures/simulations.fixtures'
+import { UPDATE_USER_ROUTE } from './fixtures/users.fixture'
 
 describe('Given a NGC user', () => {
   const agent = supertest(app)
-  const url = '/users/v1/:userId'
+  const url = UPDATE_USER_ROUTE
 
   afterEach(() =>
     Promise.all([

--- a/src/features/users/events/UserUpdated.event.ts
+++ b/src/features/users/events/UserUpdated.event.ts
@@ -4,7 +4,11 @@ import { EventBusEvent } from '../../../core/event-bus/event'
 
 export class UserUpdatedEvent extends EventBusEvent<{
   user: Pick<User, 'id' | 'name' | 'email'>
-  listIds?: ListIds[]
+  newsletters: {
+    newslettersToUnsubscribe: Set<ListIds>
+    finalNewsletters: Set<ListIds>
+  }
+  verified?: boolean
 }> {
   name = 'UserUpdatedEvent'
 }

--- a/src/features/users/handlers/add-or-update-brevo-contact.ts
+++ b/src/features/users/handlers/add-or-update-brevo-contact.ts
@@ -1,18 +1,31 @@
-import { addOrUpdateContactAndNewsLetterSubscriptions } from '../../../adapters/brevo/client'
+import {
+  addOrUpdateContactAndAddToNewsletters,
+  removeFromNewsletters,
+} from '../../../adapters/brevo/client'
 import type { Handler } from '../../../core/event-bus/handler'
 import type { UserUpdatedEvent } from '../events/UserUpdated.event'
 
 export const addOrUpdateBrevoContact: Handler<UserUpdatedEvent> = async ({
   attributes: {
     user: { email, ...user },
-    listIds,
+    newsletters: { newslettersToUnsubscribe, finalNewsletters },
+    verified,
   },
 }) => {
-  if (!email) {
+  if (!verified || !email) {
     return
   }
 
-  return addOrUpdateContactAndNewsLetterSubscriptions({
+  if (!!newslettersToUnsubscribe.size) {
+    await removeFromNewsletters({
+      listIds: Array.from(newslettersToUnsubscribe),
+      email,
+    })
+  }
+
+  const listIds = Array.from(finalNewsletters)
+
+  await addOrUpdateContactAndAddToNewsletters({
     listIds,
     email,
     user,

--- a/src/features/users/handlers/send-brevo-newsletter-confirmation-email.ts
+++ b/src/features/users/handlers/send-brevo-newsletter-confirmation-email.ts
@@ -1,0 +1,29 @@
+import { sendNewsLetterConfirmationEmail } from '../../../adapters/brevo/client'
+import { config } from '../../../config'
+import type { Handler } from '../../../core/event-bus/handler'
+import { generateVerificationCode } from '../../authentication/verification-codes.service'
+import type { UserUpdatedEvent } from '../events/UserUpdated.event'
+
+export const sendBrevoNewsLetterConfirmationEmail: Handler<
+  UserUpdatedEvent
+> = async ({
+  attributes: {
+    user: { email, id: userId },
+    newsletters: { finalNewsletters },
+    verified,
+  },
+}) => {
+  if (verified || !email) {
+    return
+  }
+
+  const { code } = await generateVerificationCode({ email })
+
+  return sendNewsLetterConfirmationEmail({
+    newsLetterConfirmationBaseUrl: config.serverUrl,
+    listIds: Array.from(finalNewsletters),
+    userId,
+    email,
+    code,
+  })
+}

--- a/src/features/users/handlers/send-brevo-newsletter-confirmation-email.ts
+++ b/src/features/users/handlers/send-brevo-newsletter-confirmation-email.ts
@@ -17,7 +17,7 @@ export const sendBrevoNewsLetterConfirmationEmail: Handler<
     return
   }
 
-  const { code } = await generateVerificationCode({ email })
+  const { code } = await generateVerificationCode({ email, userId })
 
   return sendNewsLetterConfirmationEmail({
     newsLetterConfirmationBaseUrl: config.serverUrl,

--- a/src/features/users/users.controller.ts
+++ b/src/features/users/users.controller.ts
@@ -2,10 +2,13 @@ import express from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { validateRequest } from 'zod-express-middleware'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException'
+import { ForbiddenException } from '../../core/errors/ForbiddenException'
 import { EventBus } from '../../core/event-bus/event-bus'
 import logger from '../../logger'
+import { authentificationMiddleware } from '../../middlewares/authentificationMiddleware'
 import { UserUpdatedEvent } from './events/UserUpdated.event'
 import { addOrUpdateBrevoContact } from './handlers/add-or-update-brevo-contact'
+import { sendBrevoNewsLetterConfirmationEmail } from './handlers/send-brevo-newsletter-confirmation-email'
 import { fetchUserContact, updateUserAndContact } from './users.service'
 import {
   FetchUserContactValidator,
@@ -37,29 +40,44 @@ router
   })
 
 EventBus.on(UserUpdatedEvent, addOrUpdateBrevoContact)
+EventBus.on(UserUpdatedEvent, sendBrevoNewsLetterConfirmationEmail)
 
 /**
- * Updates user for given user id
+ * Upserts user for given user id
  */
 router
   .route('/v1/:userId')
-  .put(validateRequest(UpdateUserValidator), async (req, res) => {
-    try {
-      const contact = await updateUserAndContact({
-        params: req.params,
-        userDto: UserUpdateDto.parse(req.body),
-      })
+  .put(
+    validateRequest(UpdateUserValidator),
+    authentificationMiddleware({ passIfUnauthorized: true }),
+    async (req, res) => {
+      try {
+        if (req.user && req.user.userId !== req.params.userId) {
+          throw new ForbiddenException(`Different user ids found`)
+        }
 
-      return res.status(StatusCodes.OK).json(contact)
-    } catch (err) {
-      if (err instanceof EntityNotFoundException) {
-        return res.status(StatusCodes.NOT_FOUND).send(err.message).end()
+        const { user, verified } = await updateUserAndContact({
+          params: req.user || req.params,
+          userDto: UserUpdateDto.parse(req.body),
+        })
+
+        return verified
+          ? res.status(StatusCodes.OK).json(user)
+          : res.status(StatusCodes.ACCEPTED).json(user)
+      } catch (err) {
+        if (err instanceof EntityNotFoundException) {
+          return res.status(StatusCodes.NOT_FOUND).send(err.message).end()
+        }
+
+        if (err instanceof ForbiddenException) {
+          return res.status(StatusCodes.FORBIDDEN).send(err.message).end()
+        }
+
+        logger.error('User update failed', err)
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
       }
-
-      logger.error('User update failed', err)
-
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
     }
-  })
+  )
 
 export default router

--- a/src/features/users/users.validator.ts
+++ b/src/features/users/users.validator.ts
@@ -39,3 +39,28 @@ export const UpdateUserValidator = {
   params: UserParams,
   query: z.object({}).strict().optional(),
 }
+
+export const NewsletterConfirmationQuery = z.object({
+  code: z.string().regex(/^\d{6}$/),
+  email: z
+    .string()
+    .regex(EMAIL_REGEX)
+    .transform((email) => email.toLocaleLowerCase()),
+  listIds: z
+    .union([
+      z.coerce.number().pipe(z.nativeEnum(ListIds).transform((s) => [s])),
+      z.array(z.coerce.number().pipe(z.nativeEnum(ListIds))),
+    ])
+    .optional()
+    .transform((listIds) => listIds || []),
+})
+
+export type NewsletterConfirmationQuery = z.infer<
+  typeof NewsletterConfirmationQuery
+>
+
+export const NewsletterConfirmationValidator = {
+  body: z.object({}).optional(),
+  params: UserParams,
+  query: NewsletterConfirmationQuery,
+}

--- a/src/routes/settings/getNewsletterSubscriptions.ts
+++ b/src/routes/settings/getNewsletterSubscriptions.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { fetchContact } from '../../adapters/brevo/client'
+import { fetchContactOrThrow } from '../../adapters/brevo/client'
 
 const router = express.Router()
 
@@ -18,7 +18,7 @@ router.route('/').get(async (req, res) => {
   }
 
   try {
-    const { listIds } = await fetchContact(email)
+    const { listIds } = await fetchContactOrThrow(email)
     return res.status(200).json(listIds)
   } catch (error) {
     console.warn(error)

--- a/src/routes/settings/updateSettings.ts
+++ b/src/routes/settings/updateSettings.ts
@@ -1,6 +1,9 @@
 import axios from 'axios'
 import express from 'express'
-import { addOrUpdateContact, fetchContact } from '../../adapters/brevo/client'
+import {
+  addOrUpdateContact,
+  fetchContactOrThrow,
+} from '../../adapters/brevo/client'
 import { Attributes } from '../../adapters/brevo/constant'
 import { axiosConf } from '../../constants/axios'
 import { createOrUpdateUser } from './createOrUpdateUser'
@@ -30,7 +33,7 @@ router.route('/').post(async (req, res) => {
       let currentListIds: number[]
 
       try {
-        ;({ listIds: currentListIds } = await fetchContact(email))
+        ;({ listIds: currentListIds } = await fetchContactOrThrow(email))
       } catch (e) {
         console.warn(e)
         // The contact does not exist in Brevo

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -33,9 +33,15 @@ export type Situation = {
   [key: string]: NodeValue
 }
 
-type WithRequiredProperty<Type, Keys extends keyof Type> = Type & {
+export type WithRequiredProperty<Type, Keys extends keyof Type> = Type & {
   [Property in Keys]-?: Type[Property]
 }
+
+export type WithOptionalProperty<T, O extends keyof T> = Pick<
+  T,
+  Exclude<keyof T, O>
+> &
+  Partial<{ [P in O]: T[P] }>
 
 type ValueToDto<T> = T extends Function
   ? never

--- a/vite.env.ts
+++ b/vite.env.ts
@@ -14,4 +14,5 @@ export default () => {
   process.env.SCALEWAY_ENDPOINT = 'https://s3.fr-par.scw.cloud'
   process.env.SCALEWAY_REGION = 'fr-par'
   process.env.SCALEWAY_ROOT_PATH = 'ngc'
+  process.env.SERVER_URL = 'https://server.nosgestesclimat.fr'
 }


### PR DESCRIPTION
Specs update newsletters

```
   ✓ Given a NGC user > When updating his/her profile > And invalid userId > Then it returns a 400 error
   ✓ Given a NGC user > When updating his/her profile > And invalid email > Then it returns a 400 error
   ✓ Given a NGC user > When updating his/her profile > And invalid newsletters > Then it returns a 400 error
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user does not already exist > Then it sends an email and returns a 202 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user does not already exist > And name > Then it sends an email and returns a 202 response but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user does not already exist > And no email provided > Then it returns a 200 response with the updated user
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user does not already exist > And no email provided > And name > Then it returns a 200 response with the updated user but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has no brevo contact > Then it sends an email and returns a 202 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has no brevo contact > And name > Then it sends an email and returns a 202 response but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has no brevo contact > And no email provided > Then it returns a 200 response with the updated user
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has no brevo contact > And no email provided > And name > Then it returns a 200 response with the updated user but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has a brevo contact > Then it sends an email and returns a 202 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has a brevo contact > And name > Then it sends an email and returns a 202 response but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has a brevo contact > And no email provided > Then it returns a 200 response with the updated user
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has no email > And has a brevo contact > And no email provided > And name > Then it returns a 200 response with the updated user but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has no brevo contact > And no email provided > Then it sends an email and returns a 202 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has no brevo contact > And no email provided > And name > Then it sends an email and returns a 202 response but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has no brevo contact > And new email provided > Then it sends an email and returns a 202 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has no brevo contact > And new email provided > And name > Then it sends an email and returns a 202 response but stores the name
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has a brevo contact > Then it sends an email and returns a 202 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has a brevo contact > And contact has already subscribed to the newsletter > Then it returns a 200 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has a brevo contact > And contact has already subscribed to the newsletter > And name > Then it returns a 200 response
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has a brevo contact > And contact has already subscribed to more newsletters > Then it returns a 403 error
   ✓ Given a NGC user > And logged out > When subscribing to newsletter > And user already exists > And has an email > And has a brevo contact > And contact has already subscribed to technical newsletters > Then it returns a 200 response and not unsubscribe technical newsletter
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user does not already exist > Then it returns a 200 response
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user does not already exist > And no email provided > Then it returns a 200 response with the updated user
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has no email > And has no brevo contact > Then it returns a 200 response
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has no email > And has no brevo contact > And no email provided > Then it returns a 200 response with the updated user
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has no email > And has a brevo contact > Then it returns a 200 response
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has no email > And has a brevo contact > And no email provided > Then it returns a 200 response with the updated user
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has an email > And has no brevo contact > And no email provided > Then it returns a 200 response
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has an email > And has no brevo contact > And new email provided > Then it returns a 202 response
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has an email > And has a brevo contact > Then it returns a 202 response
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has an email > And has a brevo contact > And contact has already subscribed to the newsletter > Then it returns a 403 error
   ✓ Given a NGC user > And logged out > When unsubscribing from newsletters > And user already exists > And has an email > And has a brevo contact > And contact has already subscribed to technical newsletters > Then it returns a 403 error
   ✓ Given a NGC user > And logged in > When subscribing to newsletter > Then it returns a 200 response with updated contact
   ✓ Given a NGC user > And logged in > When unsubscribing from newsletter > And contact has no previous newsletter subscription > Then it returns a 200 response with updated contact
   ✓ Given a NGC user > And logged in > When unsubscribing from newsletter > And contact has previous newsletter subscriptions > Then it returns a 200 response with updated contact
   ✓ Given a NGC user > And logged in > When unsubscribing from newsletter > And contact has previous technical newsletter subscriptions > Then it returns a 200 response with updated contact
   ✓ Given a NGC user > And database failure > Then it returns a 500 error
   ✓ Given a NGC user > And database failure > Then it logs the exception
```

Specs confirm newsletter

```
   ✓ Given a NGC user > When clicking the confirmation email link > And invalid userId > Then it returns a 400 error
   ✓ Given a NGC user > When clicking the confirmation email link > And invalid email > Then it returns a 400 error
   ✓ Given a NGC user > When clicking the confirmation email link > And invalid newsLetters > Then it returns a 400 error
   ✓ Given a NGC user > When clicking the confirmation email link > And database failure > Then it redirects to an error page
   ✓ Given a NGC user > When clicking the confirmation email link > And database failure > Then it logs the exception
   ✓ Given a NGC user > With an ongoing newsletter subscription request > And main newsletter > When clicking the confirmation email link > Then it redirects to a success page
   ✓ Given a NGC user > With an ongoing newsletter subscription request > And main newsletter > When clicking the confirmation email link > And custom user origin (preprod) > Then it redirects to a success page
   ✓ Given a NGC user > With an ongoing newsletter subscription request > And several newsletters > When clicking the confirmation email link > Then it redirects to a success page
   ✓ Given a NGC user > With an ongoing newsletter subscription request > And user already has a brevo contact with some subscribed news letters > When clicking the confirmation email link > Then it redirects to a success page
   ✓ Given a NGC user > With an expired newsletter subscription request > When clicking the confirmation email link > Then it redirects to an error page
```